### PR TITLE
ci: 修复 release 漏打了 wanxiang-lts-zh-predict.db

### DIFF
--- a/.github/workflows/schema-release.yml
+++ b/.github/workflows/schema-release.yml
@@ -2,7 +2,8 @@ name: Release Schema
 on:
   push:
     tags:
-      - 'v*'   # 触发：以 v 开头的标签，如 v1.0.0
+      - "v*" # 触发：以 v 开头的标签，如 v1.0.0
+  workflow_dispatch: # 手动触发工作流
 
 concurrency:
   group: release-standard
@@ -19,12 +20,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Extract tag version
         id: extract_tag
@@ -33,118 +34,8 @@ jobs:
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
           echo "RELEASE_TITLE=${TAG_VERSION} Rime万象拼音输入方案，全新词库，全新语法模型" >> $GITHUB_ENV
 
-
-      - name: Prepare and backup default.yaml
-        run: |
-          mkdir -p dist
-          cp default.yaml default.backup.yaml
-
-      - name: Pack standard version into rime-wanxiang.zip
-        run: |
-          # 先还原 default.yaml
-          cp default.backup.yaml default.yaml
-          # 删除 wanxiang_pro 行
-          sed -i '/^[[:space:]]*- schema: wanxiang_pro$/d' default.yaml
-
-          ROOT_FILES=$(find . -maxdepth 1 -type f \( -iname "*.yaml" -o -iname "*.txt" -o -iname "*.ini" -o -iname "*.md" -o -iname "*.png" -o -iname "*.jpg" -o -iname "*.db" \) \
-          ! -iname "wanxiang_pro*" ! -iname "wanxiang_lookup*" ! -iname "wanxiang_charset*" ! -iname "default.yaml" ! -iname "default.backup.yaml")
-
-          zip -r dist/rime-wanxiang-base.zip \
-            custom/wanxiang.custom.yaml \
-            custom/wanxiang_en.custom.yaml \
-            custom/wanxiang_radical.custom.yaml \
-            custom/*.md \
-            custom/*.jpg \
-            custom/*.png \
-            en_dicts \
-            jm_dicts \
-            lua \
-            opencc \
-            zh_dicts \
-            default.yaml \
-            $ROOT_FILES
-
-      - name: Process Rime PRO dicts using Python script
-        run: |
-          pip install --upgrade pip
-          python custom/万象分包.py
-
-      - name: Generate fuzhu scheme zip packages
-        run: |
-          declare -A types=(
-            [zrm]=pro-zrm-fuzhu-dicts
-            [moqi]=pro-moqi-fuzhu-dicts
-            [flypy]=pro-flypy-fuzhu-dicts
-            [jdh]=pro-jdh-fuzhu-dicts
-            [hanxin]=pro-hanxin-fuzhu-dicts
-            [wubi]=pro-wubi-fuzhu-dicts
-            [tiger]=pro-tiger-fuzhu-dicts
-          )
-
-          for type in "${!types[@]}"; do
-            dict_dir="${types[$type]}"
-            work_dir="tmp_${type}"
-
-            echo "🧹 清理并创建工作目录: $work_dir"
-            rm -rf "$work_dir"
-            mkdir -p "$work_dir/zh_dicts_pro"
-
-            echo "📦 复制分包词库: $dict_dir → $work_dir/zh_dicts_pro/"
-            cp -r "$dict_dir/"* "$work_dir/zh_dicts_pro/"
-
-            echo "📍生成 lookup 分包文件（按类型 $type）"
-            python custom/lookup分包.py "$type"
-
-            echo "📥 复制该类型的 lookup 分包文件 → wanxiang_lookup.dict.yaml"
-            cp "wanxiang_lookup_${type}.dict.yaml" "$work_dir/wanxiang_lookup.dict.yaml"
-
-            echo "📄 复制 default.yaml 并修改"
-            cp default.backup.yaml "$work_dir/default.yaml"
-            sed -i '/^[[:space:]]*- schema: wanxiang$/d' "$work_dir/default.yaml"
-
-            echo "🧩 复制 custom 配置"
-            mkdir -p "$work_dir/custom"
-            cp custom/wanxiang_pro.custom.yaml "$work_dir/custom/"
-            cp custom/wanxiang_en.custom.yaml "$work_dir/custom/"
-            cp custom/wanxiang_radical.custom.yaml "$work_dir/custom/"
-            cp custom/*.md "$work_dir/custom/" 2>/dev/null || true
-            cp custom/*.png "$work_dir/custom/" 2>/dev/null || true
-            cp custom/*.jpg "$work_dir/custom/" 2>/dev/null || true
-
-            echo "📄 复制 schema 主文件"
-            cp wanxiang_pro.dict.yaml "$work_dir/wanxiang_pro.dict.yaml"
-            cp custom/预设分包方案.yaml "$work_dir/wanxiang_pro.schema.yaml"
-            cp wanxiang_lookup.schema.yaml "$work_dir/wanxiang_lookup.schema.yaml"
-
-            echo "📁 拷贝模块子目录"
-            cp -r en_dicts "$work_dir/"
-            cp -r jm_dicts "$work_dir/"
-            cp -r lua "$work_dir/"
-            cp -r opencc "$work_dir/"
-
-            echo "🗃 合并根目录的通用文件"
-            find . -maxdepth 1 -type f \( \
-              -iname "*.yaml" -o -iname "*.txt" -o -iname "*.md" -o -iname "*.png" -o -iname "*.jpg" -o -iname "*.db" -o -iname "*.ini" -o -iname "*.db" \
-              \) \
-              ! -iname "wanxiang_pro*" \
-              ! -iname "wanxiang_lookup*" \
-            #  ! -iname "wanxiang_charset*" \
-              ! -iname "wanxiang.dict.yaml" \
-              ! -iname "wanxiang.schema.yaml" \
-              ! -iname "default.yaml" \
-              ! -iname "default.backup.yaml" \
-              -exec cp {} "$work_dir/" \;
-
-            echo "📦 打包为扁平结构 zip"
-            (cd "$work_dir" && zip -r "../dist/rime-wanxiang-${type}-fuzhu.zip" .)
-
-            echo "🧹 清理中间文件"
-            rm -rf "$work_dir"
-            rm -f wanxiang_lookup_${type}.dict.yaml
-
-            echo "✅ 完成打包: rime-wanxiang-${type}-fuzhu.zip"
-          done
-  
+      - name: Release build
+        run: bash .github/workflows/scripts/release-build.sh
 
       - name: Generate changelog from commits
         shell: bash
@@ -158,7 +49,7 @@ jobs:
           echo "" >> release_notes.md
           echo "#### 2. 双拼辅助码增强版输入方案" >> release_notes.md
           echo "✨**适用类型：** 支持各种双拼+辅助码的自由组合" >> release_notes.md
-      
+
           declare -A display_names=(
             [zrm]="自然码"
             [moqi]="墨奇"
@@ -168,12 +59,12 @@ jobs:
             [wubi]="五笔前2"
             [tiger]="虎码首末"
           )
-      
+
           for type in zrm moqi flypy jdh hanxin wubi tiger; do
             name="${display_names[$type]}"
             echo "- **${name}辅助版本：** [rime-wanxiang-${type}-fuzhu.zip](https://github.com/${{ github.repository }}/releases/download/${TAG_VERSION}/rime-wanxiang-${type}-fuzhu.zip)" >> release_notes.md
           done
-      
+
           echo "" >> release_notes.md
           echo "#### 3. 语法模型" >> release_notes.md
           echo "✨**适用类型：** 所有版本皆可用" >> release_notes.md
@@ -199,17 +90,15 @@ jobs:
           echo "4. 💾 飞机盘下载地址（最快更新）：[点击访问](https://share.feijipan.com/s/xiGvXdKz)" >> release_notes.md
           echo "5. 🛠 推荐使用更新脚本优雅管理版本：[rime-wanxiang-weasel-update-tools](https://github.com/expoli/rime-wanxiang-weasel-update-tools)" >> release_notes.md
 
-        
-
       - name: Create Release and Upload
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ env.RELEASE_TITLE }}         #发布页标题
+          name: ${{ env.RELEASE_TITLE }} #发布页标题
           tag_name: ${{ github.ref_name }}
           files: |
             dist/rime-wanxiang-*.zip
           body_path: release_notes.md
-          draft: false
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/release-build.sh
+++ b/.github/workflows/scripts/release-build.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# 打包对用方案到 zip 文件，放到 dist 目录
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/../../../" && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+CUSTOM_DIR="$ROOT_DIR/custom"
+
+# 成成 PRO 分包文件
+python3 "$CUSTOM_DIR/万象分包.py"
+echo "✅ PRO 完成: 生成完毕"
+echo
+
+package_schema_base() {
+    OUT_DIR=$1
+    rm -rf "$OUT_DIR"
+    mkdir -p "$OUT_DIR"
+
+    # 1. 拷贝 custom/ 下除 wanxiang_pro.custom* 外的所有 yaml、md、jpg、ng 文件
+    mkdir -p "$OUT_DIR"/custom
+    find "$CUSTOM_DIR" -type f \( -name "*.yaml" -o -name "*.md" -o -name "*.jpg" -o -name "*.png" \) \
+        ! -name "wanxiang_pro.custom*" -exec cp {} "$OUT_DIR"/custom \;
+
+    # 2. 拷贝根目录下除指定内容外的文件/文件夹
+    for item in "$ROOT_DIR"/*; do
+        name="$(basename "$item")"
+        if [[ "$name" =~ ^\. ]]; then continue; fi
+        if [[ "$name" == "pro-"*-fuzhu-dicts ]]; then continue; fi
+        if [[ "$name" == "wanxiang_pro.dict.yaml" || "$name" == "wanxiang_pro.schema.yaml" ]]; then continue; fi
+        if [[ "$name" == "custom_phrase_flypy.txt" ]]; then continue; fi
+        if [[ "$name" == "zh_dicts_pro" ]]; then continue; fi
+        if [[ "$name" == "custom" || "$name" == "dist" ]]; then continue; fi
+        cp -r "$item" "$OUT_DIR/"
+    done
+
+    # 3. 修改 default.yaml，删除 schema_list: 中的 - schema: wanxiang_pro
+    sed -i '/- schema: wanxiang_pro/d' "$OUT_DIR/default.yaml"
+}
+
+package_schema_pro() {
+    SCHEMA_NAME="$1"
+    OUT_DIR="$2"
+    rm -rf "$OUT_DIR"
+    mkdir -p "$OUT_DIR"
+
+    # 1. 生成 pro-方案名-fuzhu-dicts 并重命名为 zh_dicts_pro
+    if [[ -d "$ROOT_DIR/pro-$SCHEMA_NAME-fuzhu-dicts" ]]; then
+        mv "$ROOT_DIR/pro-$SCHEMA_NAME-fuzhu-dicts" "$OUT_DIR/zh_dicts_pro"
+    fi
+
+    # 2. 生成 lookup-方案名.yaml 并重命名
+    python3 "$CUSTOM_DIR/lookup分包.py" "$SCHEMA_NAME"
+    if [[ -f "$ROOT_DIR/wanxiang_lookup_$SCHEMA_NAME.dict.yaml" ]]; then
+        mv "$ROOT_DIR/wanxiang_lookup_$SCHEMA_NAME.dict.yaml" "$OUT_DIR/wanxiang_lookup.dict.yaml"
+    fi
+
+    # 3. 拷贝 custom/ 下除 wanxiang.custom.yaml 外的所有 yaml、md、jpg、ng 文件
+    mkdir -p "$OUT_DIR"/custom
+    find "$CUSTOM_DIR" -type f \( -name "*.yaml" -o -name "*.md" -o -name "*.jpg" -o -name "*.png" \) \
+        ! -name "wanxiang.custom.yaml" -exec cp {} "$OUT_DIR"/custom \;
+
+    # 4. 拷贝根目录下除指定内容外的文件/文件夹
+    for item in "$ROOT_DIR"/*; do
+        name="$(basename "$item")"
+        if [[ "$name" =~ ^\. ]]; then continue; fi
+        if [[ "$name" == "pro-"*-fuzhu-dicts ]]; then continue; fi
+        if [[ "$name" == "wanxiang.dict.yaml" || "$name" == "wanxiang.schema.yaml" ]]; then continue; fi
+        if [[ "$name" == "zh_dicts" ]]; then continue; fi
+        if [[ -e "$OUT_DIR/$name" ]]; then continue; fi
+        if [[ "$name" == "custom" || "$name" == "dist" ]]; then continue; fi
+        cp -r "$item" "$OUT_DIR/"
+    done
+
+    # 5. 修改 default.yaml，删除 schema_list: 中的 - schema: wanxiang
+    sed -i '/- schema: wanxiang$/d' "$OUT_DIR/default.yaml"
+}
+
+package_schema() {
+    SCHEMA_NAME="$1"
+    echo "▶️ 开始打包方案：$SCHEMA_NAME"
+
+    if [[ "$SCHEMA_NAME" == "base" ]]; then
+        OUT_DIR="$DIST_DIR/rime-wanxiang-base"
+        package_schema_base "$OUT_DIR"
+
+        ZIP_NAME=rime-wanxiang-"$SCHEMA_NAME".zip
+    else
+        OUT_DIR="$DIST_DIR/rime-wanxiang-$SCHEMA_NAME-fuzhu"
+        package_schema_pro "$SCHEMA_NAME" "$OUT_DIR"
+
+    fi
+
+    ZIP_NAME=$(basename "$OUT_DIR").zip
+    (cd "$OUT_DIR" && zip -r -q ../"$ZIP_NAME" . && cd ..)
+    echo "✅ 完成打包: $ZIP_NAME"
+    echo
+}
+
+SCHEMA_LIST=("base" "flypy" "hanxin" "jdh" "moqi" "tiger" "wubi" "zrm")
+
+# 如果没有传入参数，则循环 package 所有的
+if [[ -z "$SCHEMA_NAME" ]]; then
+    for name in "${SCHEMA_LIST[@]}"; do
+        package_schema "$name"
+    done
+    exit 0
+fi
+
+if [[ ! " ${SCHEMA_LIST[*]} " =~ ${SCHEMA_NAME} ]]; then
+    echo "参数错误: 只支持 ${SCHEMA_LIST[*]}" >&2
+    exit 1
+fi
+
+package_schema "$SCHEMA_NAME"


### PR DESCRIPTION
将打包脚本重构到单独的脚本中，并支持手动触发构建发布 draft release，方便测试

![图片](https://github.com/user-attachments/assets/69037d5d-e07d-4ac2-b8b7-fe04f4fb0e1b)
