### PR TITLE
chore: 清理不应追踪的lua数据文件seq_words.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # lua 目录下动态生成的记录文件，不应被 git 追踪
 lua/input_stats.lua
+lua/seq_words.lua
 # 本地测试打包时的临时文件
 dist
 pro-*-fuzhu-dicts

--- a/lua/seq_words.lua
+++ b/lua/seq_words.lua
@@ -1,3 +1,0 @@
-local seq_words = {
-}
-return seq_words


### PR DESCRIPTION
在 Windows 下测试了一下，也是能正常生成的