### PR TITLE
添加东风破plum安装及更新recipe

### DIFF
--- a/others/recipes/all_dicts.recipe.yaml
+++ b/others/recipes/all_dicts.recipe.yaml
@@ -1,0 +1,16 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/all_dicts
+  args:
+  description: >-
+    所有词库安装、更新
+install_files: >-
+  zh_dicts/*.*
+  zh_dicts_pro/*.*
+  jm_dicts/*.*
+  lookup/*.*
+  wanxiang_charset.dict.yaml
+  wanxiang_radical.dict.yaml
+  wanxiang_stroke.dict.yaml
+  en_dicts/*.*

--- a/others/recipes/charset.recipe.yaml
+++ b/others/recipes/charset.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/charset
+  args:
+  description: >-
+    字符集过滤器安装、更新
+install_files: >-
+  wanxiang_charset.dict.yaml

--- a/others/recipes/en_dicts.recipe.yaml
+++ b/others/recipes/en_dicts.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/en_dicts
+  args:
+  description: >-
+    英文词库安装、更新
+install_files: >-
+  en_dicts/*.*

--- a/others/recipes/jm_dicts.recipe.yaml
+++ b/others/recipes/jm_dicts.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/jm_dicts
+  args:
+  description: >-
+    简码词库安装、更新
+install_files: >-
+  jm_dicts/*.*

--- a/others/recipes/lookup.recipe.yaml
+++ b/others/recipes/lookup.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/lookup
+  args:
+  description: >-
+    万象注释滤镜安装、更新
+install_files: >-
+  lookup/*.*

--- a/others/recipes/lua.recipe.yaml
+++ b/others/recipes/lua.recipe.yaml
@@ -1,0 +1,10 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/opencc
+  args:
+  description: >-
+    opencc(Emoji)安装、更新
+install_files: >-
+  lua/*.*
+  lua/tips/*.*

--- a/others/recipes/lua.recipe.yaml
+++ b/others/recipes/lua.recipe.yaml
@@ -1,10 +1,10 @@
 # encoding: utf-8
 ---
 recipe:
-  Rx: others/recipes/opencc
+  Rx: others/recipes/lua
   args:
   description: >-
-    opencc(Emoji)安装、更新
+    lua安装、更新
 install_files: >-
   lua/*.*
   lua/tips/*.*

--- a/others/recipes/opencc.recipe.yaml
+++ b/others/recipes/opencc.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/opencc
+  args:
+  description: >-
+    opencc(Emoji)安装、更新
+install_files: >-
+  opencc/*.*

--- a/others/recipes/radical.recipe.yaml
+++ b/others/recipes/radical.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/radical
+  args:
+  description: >-
+    拆字词库安装、更新
+install_files: >-
+  wanxiang_radical.dict.yaml

--- a/others/recipes/stroke.recipe.yaml
+++ b/others/recipes/stroke.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/stroke
+  args:
+  description: >-
+    笔画反查词库安装、更新
+install_files: >-
+  wanxiang_stroke.dict.yaml

--- a/others/recipes/zh_dicts.recipe.yaml
+++ b/others/recipes/zh_dicts.recipe.yaml
@@ -1,7 +1,7 @@
 # encoding: utf-8
 ---
 recipe:
-  Rx: others/recipes/cn_dicts
+  Rx: others/recipes/zh_dicts
   args:
   description: >-
     中文词库安装、更新

--- a/others/recipes/zh_dicts.recipe.yaml
+++ b/others/recipes/zh_dicts.recipe.yaml
@@ -1,0 +1,15 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/cn_dicts
+  args:
+  description: >-
+    中文词库安装、更新
+install_files: >-
+  zh_dicts/*.*
+  zh_dicts_pro/*.*
+  jm_dicts/*.*
+  lookup/*.*
+  wanxiang_charset.dict.yaml
+  wanxiang_radical.dict.yaml
+  wanxiang_stroke.dict.yaml

--- a/others/recipes/zh_dicts.recipe.yaml
+++ b/others/recipes/zh_dicts.recipe.yaml
@@ -7,9 +7,4 @@ recipe:
     中文词库安装、更新
 install_files: >-
   zh_dicts/*.*
-  zh_dicts_pro/*.*
-  jm_dicts/*.*
-  lookup/*.*
-  wanxiang_charset.dict.yaml
-  wanxiang_radical.dict.yaml
-  wanxiang_stroke.dict.yaml
+  

--- a/others/recipes/zh_dicts_pro.recipe.yaml
+++ b/others/recipes/zh_dicts_pro.recipe.yaml
@@ -1,0 +1,9 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: others/recipes/zh_dicts_pro
+  args:
+  description: >-
+    中文词库（pro版）安装、更新
+install_files: >-
+  zh_dicts_pro/*.*


### PR DESCRIPTION
对于使用东风破（plum）管理输入方案包以及将万象拼音词库移植到其他输入方案的用户，可以简化万象词库的维护流程。

可用命令包括：

```bash
# 完整词库（含以下中英文词库及其他功能性词库）
bash rime-install KingfuChan/rime_wanxiang:others/recipes/all_dicts
# 中文及其他功能性词库
bash rime-install KingfuChan/rime_wanxiang:others/recipes/zh_dicts
bash rime-install KingfuChan/rime_wanxiang:others/recipes/zh_dicts_pro
bash rime-install KingfuChan/rime_wanxiang:others/recipes/jm_dicts
bash rime-install KingfuChan/rime_wanxiang:others/recipes/lookup
bash rime-install KingfuChan/rime_wanxiang:others/recipes/charset
bash rime-install KingfuChan/rime_wanxiang:others/recipes/radical
bash rime-install KingfuChan/rime_wanxiang:others/recipes/stroke
# 英文词库
bash rime-install KingfuChan/rime_wanxiang:others/recipes/en_dicts
# opencc
bash rime-install KingfuChan/rime_wanxiang:others/recipes/opencc
# lua
bash rime-install KingfuChan/rime_wanxiang:others/recipes/lua
```

上述代码合并后可以将`KingfuChan/rime_wanxiang`替换为`amzxyz/rime_wanxiang`

新增的recipes文件参考自雾凇拼音。可能需要修改分包、打包脚本以将新增recipe文件排除在外。