### PR TITLE
修改方案选单显示的名称，更易于理解

### DIFF
--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -32,27 +32,36 @@ schema:
 # abbrev: 默认的缩写取 states 的第一个字符，abbrev 可自定义一个字符
 switches:
   - name: ascii_mode                    # 中英输入状态
+    abbrev: [中,英]
     states: [ 中文, 英文 ]
   - name: ascii_punct                   # 中英标点，可以在中文输入状态输入英文符号
+    abbrev: [¥,$]
     states: [ 中标, 英标 ]
   - name: full_shape                    #全角、半角字符输出
     states: [ 半角, 全角 ]
   - name: emoji                         #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
+    abbrev: [🙃,😄]
     states: [ emoji关, emoji开 ]
   - name: chinese_english               #候选进入翻译模式滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，归属opencc 翻译滤镜
+    abbrev: [译,翻]
     states: [ 翻译关, 翻译开 ]
   - name: tone_display                  #开启后在输入编码的位置实时转换为带声调全拼，不开启则采用系统配置，影响的是preedit_format,归属：super_preedit.lua
+    abbrev: [调,声]
     states: [ 声调关, 声调开 ]
   - name: tone_hint                    #开启后在候选的注释里面实时显示全拼声调，不开启则采用系统配置，影响的是comment_format，归属：super_comment.lua
+    abbrev: [音,读]
     states: [ 读音关, 读音开 ]
   - name: super_tips                    #开启后在输入编码后面的提示区显示实时的提示数据，受tips数据库影响，表情、翻译、车牌、符号等对应关系数据，并可实现句号上屏，不开启则默认，影响的是segment.prompt参数，归属：super_tips.lua
+    abbrev: [off,tips]
     states: [ tips关, tips开 ]
     reset: 1
   - options: [ s2s, s2t, s2hk, s2tw ]   # 简繁转换开关组，可以在一个空选项和多个实际“- simplifier@s2hk”引入的项目之前切换，这是一个开关组，你可以将其中任意一个s2s等设置为toggle快捷键，多次按下将轮询
     states: [ 简体, 通繁, 港繁, 臺繁 ]
   - name: prediction                    #开启后输入上屏后继续弹出预测数据候选展示例如输入：你在 ，预测候选： 哪里 干嘛 吗 做等等，predictor配置区可设置详细参数，归属：predict内置插件
+    abbrev: [测,预]
     states: [ 预测关, 预测开 ]
   - name: search_single_char            #多体现在编码重合但候选有单字或者多字的情况辅码查词时是否单字优先，全拼常见，类似于特定编码情况下、反查状态下的调序能力。归属：search.lua
+    abbrev: [词,单]
     states: [正常, 单字]
 
 

--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -32,28 +32,28 @@ schema:
 # abbrev: 默认的缩写取 states 的第一个字符，abbrev 可自定义一个字符
 switches:
   - name: ascii_mode                    # 中英输入状态
-    states: [ 中, 英 ]
+    states: [ 中文, 英文 ]
   - name: ascii_punct                   # 中英标点，可以在中文输入状态输入英文符号
-    states: [ ¥, $ ]
+    states: [ 中标, 英标 ]
   - name: full_shape                    #全角、半角字符输出
-    states: [ 半, 全 ]
+    states: [ 半角, 全角 ]
   - name: emoji                         #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
-    states: [ 🙃, 😄 ]
+    states: [ emoji关, emoji开 ]
   - name: chinese_english               #候选进入翻译模式滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，归属opencc 翻译滤镜
-    states: [ 译, 翻 ]
+    states: [ 翻译关, 翻译开 ]
   - name: tone_display                  #开启后在输入编码的位置实时转换为带声调全拼，不开启则采用系统配置，影响的是preedit_format,归属：super_preedit.lua
-    states: [ 调, 声 ]
+    states: [ 声调关, 声调开 ]
   - name: tone_hint                    #开启后在候选的注释里面实时显示全拼声调，不开启则采用系统配置，影响的是comment_format，归属：super_comment.lua
-    states: [ 音, 读 ]
+    states: [ 读音关, 读音开 ]
   - name: super_tips                    #开启后在输入编码后面的提示区显示实时的提示数据，受tips数据库影响，表情、翻译、车牌、符号等对应关系数据，并可实现句号上屏，不开启则默认，影响的是segment.prompt参数，归属：super_tips.lua
-    states: [ off, tips ]
+    states: [ tips关, tips开 ]
     reset: 1
   - options: [ s2s, s2t, s2hk, s2tw ]   # 简繁转换开关组，可以在一个空选项和多个实际“- simplifier@s2hk”引入的项目之前切换，这是一个开关组，你可以将其中任意一个s2s等设置为toggle快捷键，多次按下将轮询
     states: [ 简体, 通繁, 港繁, 臺繁 ]
   - name: prediction                    #开启后输入上屏后继续弹出预测数据候选展示例如输入：你在 ，预测候选： 哪里 干嘛 吗 做等等，predictor配置区可设置详细参数，归属：predict内置插件
-    states: [ 测, 预 ]
+    states: [ 预测关, 预测开 ]
   - name: search_single_char            #多体现在编码重合但候选有单字或者多字的情况辅码查词时是否单字优先，全拼常见，类似于特定编码情况下、反查状态下的调序能力。归属：search.lua
-    states: [词, 单]
+    states: [正常, 单字]
 
 
 # 输入引擎

--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -32,36 +32,36 @@ schema:
 # abbrev: 默认的缩写取 states 的第一个字符，abbrev 可自定义一个字符
 switches:
   - name: ascii_mode                    # 中英输入状态
-    abbrev: [中,英]
+    abbrev: [中, 英]
     states: [ 中文, 英文 ]
   - name: ascii_punct                   # 中英标点，可以在中文输入状态输入英文符号
-    abbrev: [¥,$]
+    abbrev: [¥, $]
     states: [ 中标, 英标 ]
   - name: full_shape                    #全角、半角字符输出
     states: [ 半角, 全角 ]
   - name: emoji                         #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
-    abbrev: [🙃,😄]
+    abbrev: [🙃, 😄]
     states: [ emoji关, emoji开 ]
   - name: chinese_english               #候选进入翻译模式滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，归属opencc 翻译滤镜
-    abbrev: [译,翻]
+    abbrev: [译, 翻]
     states: [ 翻译关, 翻译开 ]
   - name: tone_display                  #开启后在输入编码的位置实时转换为带声调全拼，不开启则采用系统配置，影响的是preedit_format,归属：super_preedit.lua
-    abbrev: [调,声]
+    abbrev: [调, 声]
     states: [ 声调关, 声调开 ]
   - name: tone_hint                    #开启后在候选的注释里面实时显示全拼声调，不开启则采用系统配置，影响的是comment_format，归属：super_comment.lua
-    abbrev: [音,读]
+    abbrev: [音, 读]
     states: [ 读音关, 读音开 ]
   - name: super_tips                    #开启后在输入编码后面的提示区显示实时的提示数据，受tips数据库影响，表情、翻译、车牌、符号等对应关系数据，并可实现句号上屏，不开启则默认，影响的是segment.prompt参数，归属：super_tips.lua
-    abbrev: [off,tips]
+    abbrev: [off, tips]
     states: [ tips关, tips开 ]
     reset: 1
   - options: [ s2s, s2t, s2hk, s2tw ]   # 简繁转换开关组，可以在一个空选项和多个实际“- simplifier@s2hk”引入的项目之前切换，这是一个开关组，你可以将其中任意一个s2s等设置为toggle快捷键，多次按下将轮询
     states: [ 简体, 通繁, 港繁, 臺繁 ]
   - name: prediction                    #开启后输入上屏后继续弹出预测数据候选展示例如输入：你在 ，预测候选： 哪里 干嘛 吗 做等等，predictor配置区可设置详细参数，归属：predict内置插件
-    abbrev: [测,预]
+    abbrev: [测, 预]
     states: [ 预测关, 预测开 ]
   - name: search_single_char            #多体现在编码重合但候选有单字或者多字的情况辅码查词时是否单字优先，全拼常见，类似于特定编码情况下、反查状态下的调序能力。归属：search.lua
-    abbrev: [词,单]
+    abbrev: [词, 单]
     states: [正常, 单字]
 
 

--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -38,6 +38,7 @@ switches:
     abbrev: [¥, $]
     states: [ 中标, 英标 ]
   - name: full_shape                    #全角、半角字符输出
+     abbrev: [半, 全]
     states: [ 半角, 全角 ]
   - name: emoji                         #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
     abbrev: [🙃, 😄]

--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -38,7 +38,7 @@ switches:
     abbrev: [¥, $]
     states: [ 中标, 英标 ]
   - name: full_shape                    #全角、半角字符输出
-     abbrev: [半, 全]
+    abbrev: [半, 全]
     states: [ 半角, 全角 ]
   - name: emoji                         #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
     abbrev: [🙃, 😄]

--- a/wanxiang_pro.schema.yaml
+++ b/wanxiang_pro.schema.yaml
@@ -40,29 +40,40 @@ schema:
 # abbrev: 默认的缩写取 states 的第一个字符，abbrev 可自定义一个字符
 switches:
   - name: ascii_mode                   # 中英输入状态
+    abbrev: [中, 英]
     states: [ 中文, 英文 ]
   - name: ascii_punct                  # 中英标点
+    abbrev: [¥, $]
     states: [ 中标, 英标 ]
   - name: full_shape                   #全角、半角字符输出
+    abbrev: [半, 全]
     states: [ 半角, 全角 ]
   - name: emoji                        #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
+    abbrev: [🙃, 😄]
     states: [ emoji关, emoji开 ]
   - name: chinese_english              #候选进入翻译模式滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，快捷键配套ctrl+e,归属opencc 翻译滤镜
+    abbrev: [译, 翻]
     states: [ 翻译关, 翻译开 ]
   - name: tone_display                 #开启后在输入编码的位置实时转换为带声调全拼，不开启则采用系统配置，快捷键配套ctrl+s,影响的是preedit_format,归属：super_preedit.lua
+    abbrev: [调, 声]
     states: [ 声调关, 声调开 ]
   - name: chaifen_switch               #开启后在候选的注释里面实时显示辅助码的拆分提醒优先级高于普通辅助提醒，不开启则采用系统配置，快捷键配套ctrl+c,影响的是comment_format，归属：super_comment.lua
+    abbrev: [分, 拆]
     states: [ 拆分关, 拆分开 ]
   - name: charset_filter               #字符集过滤，默认开启8105通规显示，即小字集，可通过开关实时开启全字集，快捷键配套ctrl+g,归属：chars_filter.lua
+    abbrev: [小, 大]
     states: [ 小字集, 大字集 ]
   - name: super_tips                   #开启后在输入编码后面的提示区显示实时的提示数据，受tips数据库影响，表情、翻译、车牌、符号等对应关系数据，并可实现句号上屏，不开启则默认，影响的是segment.prompt参数，归属：super_tips.lua
+    abbrev: [off, tips]
     states: [ tips关, tips开 ]
     reset: 1
   - options: [ comment_off, fuzhu_hint, tone_hint ]  #开启后在候选的注释里面实时显示辅助码或者全拼声调，不开启则采用系统配置，影响的是comment_format，快捷键配套ctrl+a,归属：super_comment.lua
+    abbrev: [注关, 辅开, 调开]
     states: [ 注释关, 辅助开, 声调开 ]
   - options: [ s2s, s2t, s2hk, s2tw ]  # 简繁转换开关组，可以在一个空选项和多个实际“- simplifier@s2hk”引入的项目之前切换，这是一个开关组，你可以将其中任意一个s2s等设置为toggle快捷键，多次按下将轮询
     states: [ 简体, 通繁, 港繁, 臺繁 ]
   - name: prediction                   #开启后输入上屏后继续弹出预测数据候选展示例如输入：你在 ，预测候选： 哪里 干嘛 吗 做等等，predictor配置区可设置详细参数，归属：predict内置插件
+    abbrev: [测, 预]
     states: [ 预测关, 预测开 ]
   - name: search_single_char          #多体现在编码重合但候选有单字或者多字的情况`引导的辅码查词时是否单字优先，全拼常见，类似于特定编码情况下、反查状态下的调序能力。归属：search.lua
     abbrev: [词, 单]

--- a/wanxiang_pro.schema.yaml
+++ b/wanxiang_pro.schema.yaml
@@ -40,30 +40,30 @@ schema:
 # abbrev: 默认的缩写取 states 的第一个字符，abbrev 可自定义一个字符
 switches:
   - name: ascii_mode                   # 中英输入状态
-    states: [ 中, 英 ]
+    states: [ 中文, 英文 ]
   - name: ascii_punct                  # 中英标点
-    states: [ ¥, $ ]
+    states: [ 中标, 英标 ]
   - name: full_shape                   #全角、半角字符输出
-    states: [ 半, 全 ]
+    states: [ 半角, 全角 ]
   - name: emoji                        #候选出现emoji滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，因此默认为reset: 0，归属opencc emoji滤镜
-    states: [ 🙃, 😄 ]
+    states: [ emoji关, emoji开 ]
   - name: chinese_english              #候选进入翻译模式滤镜，会显示在相应的候选后面，万象侧重于tips提示，避免候选被占用，快捷键配套ctrl+e,归属opencc 翻译滤镜
-    states: [ 译, 翻 ]
+    states: [ 翻译关, 翻译开 ]
   - name: tone_display                 #开启后在输入编码的位置实时转换为带声调全拼，不开启则采用系统配置，快捷键配套ctrl+s,影响的是preedit_format,归属：super_preedit.lua
-    states: [ 调, 声 ]
+    states: [ 声调关, 声调开 ]
   - name: chaifen_switch               #开启后在候选的注释里面实时显示辅助码的拆分提醒优先级高于普通辅助提醒，不开启则采用系统配置，快捷键配套ctrl+c,影响的是comment_format，归属：super_comment.lua
-    states: [ 分, 拆 ]
+    states: [ 拆分关, 拆分开 ]
   - name: charset_filter               #字符集过滤，默认开启8105通规显示，即小字集，可通过开关实时开启全字集，快捷键配套ctrl+g,归属：chars_filter.lua
-    states: [ 小, 大 ]
+    states: [ 小字集, 大字集 ]
   - name: super_tips                   #开启后在输入编码后面的提示区显示实时的提示数据，受tips数据库影响，表情、翻译、车牌、符号等对应关系数据，并可实现句号上屏，不开启则默认，影响的是segment.prompt参数，归属：super_tips.lua
-    states: [ off, tips ]
+    states: [ tips关, tips开 ]
     reset: 1
   - options: [ comment_off, fuzhu_hint, tone_hint ]  #开启后在候选的注释里面实时显示辅助码或者全拼声调，不开启则采用系统配置，影响的是comment_format，快捷键配套ctrl+a,归属：super_comment.lua
-    states: [ 注关, 辅开, 调开 ]
+    states: [ 注释关, 辅助开, 声调开 ]
   - options: [ s2s, s2t, s2hk, s2tw ]  # 简繁转换开关组，可以在一个空选项和多个实际“- simplifier@s2hk”引入的项目之前切换，这是一个开关组，你可以将其中任意一个s2s等设置为toggle快捷键，多次按下将轮询
     states: [ 简体, 通繁, 港繁, 臺繁 ]
   - name: prediction                   #开启后输入上屏后继续弹出预测数据候选展示例如输入：你在 ，预测候选： 哪里 干嘛 吗 做等等，predictor配置区可设置详细参数，归属：predict内置插件
-    states: [ 测, 预 ]
+    states: [ 预测关, 预测开 ]
   - name: search_single_char          #多体现在编码重合但候选有单字或者多字的情况`引导的辅码查词时是否单字优先，全拼常见，类似于特定编码情况下、反查状态下的调序能力。归属：search.lua
     abbrev: [词, 单]
     states: [正常, 单字]


### PR DESCRIPTION
使用类似“译“”翻“这样，同一个词的两个字分别代表状态的”关“和”开“，在使用时不易于理解，也不符合直觉。
即使用了很久，我有时候也得反应一下，更别提新手了，不看注释根本不知道是做什么的。
方案选单并不是需要经常打开的，名称也不用维持那么简洁，更需要一看就明白功能。