### PR TITLE
fix(lua): super_sequence 不应使用未confirm的输入码

### DIFF
--- a/lua/super_sequence.lua
+++ b/lua/super_sequence.lua
@@ -92,7 +92,12 @@ end
 ---@param context Context
 ---@return string
 local function get_valid_input(context)
-    return context.input:sub(1, context.caret_pos)
+    local segmentation = context.composition:toSegmentation()
+    local start = segmentation:get_confirmed_position() + 1
+
+    if start > context.caret_pos then return "" end
+
+    return context.input:sub(start, context.caret_pos)
 end
 
 local P = {}


### PR DESCRIPTION
close #170

这是一种取舍。 这个版本实现下面的「方案 3」， #173 实现了「方案 2」，release 中则为「方案 1」

如果「句中手动排序」会让人难以理解的话，也可以实现 #170 禁用手动排序

---

### 场景一：「大唐国际*染料*有限公司」。

因为「染料」不是首选，整句输入时需要在句中手动排序「染料」，这里讨论这个排序的影响范围。

- 「匹配范围」指的是此排序下次出现的匹配范围。
- 「匹配范围」越短，排序影响的范围也越大。
- 「匹配范围」中的汉字为已选择的汉字，字母为输入码（这里是自然码）。

| 方案  | 匹配范围 | 备注 | 
|-------------|-------------|-------------|
| 1 | `大唐国际 rjlc yb xm gs si` | release 版本的行为，即整个 `context.input` |
| 2 | `大唐国际 rjlc` |  光标位置 caret_pos 前的 `context.input` |
| 3 | `rjlc` | `confirmed_position` 与 光标位置 `caret_pos` 间的 `context.input` |

注意：此场景用自造词或者自定义词库当然更合理，这里考虑的是做为一个快捷输入的补充