### PR TITLE
chore(lua): wanxiang.lua 支持获取当前版本号

### DIFF
--- a/lua/wanxiang.lua
+++ b/lua/wanxiang.lua
@@ -3,6 +3,10 @@
 -- 万象的一些共用工具函数
 local wanxiang = {}
 
+-- x-release-please-start-version
+wanxiang.version = "8.8.0"
+-- x-release-please-end
+
 -- 全局内容
 ---@alias PROCESS_RESULT ProcessResult
 wanxiang.RIME_PROCESS_RESULTS = {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,9 @@
     "packages": {
         ".": {
             "release-type": "simple",
+            "extra-files": [
+                "lua/wanxiang.lua"
+            ],
             "changelog-sections": [
                 {
                     "type": "feat",


### PR DESCRIPTION
release-please 机器人会在版本发布的时候自动更新 `wanxiang.lua` 中的版本号，版本号直接内嵌在 lua 中，不依赖 `version.txt`

后续可以根据此版本号的变化做一些优化或实现一下其他新功能：例如 #224