### PR TITLE
perf(lua): 使用新数据结构优化排序性能

### DIFF
--- a/lua/super_sequence.lua
+++ b/lua/super_sequence.lua
@@ -6,37 +6,87 @@
 -- ctrl+p 置顶
 local wanxiang = require("wanxiang")
 
-local Property = {
-    ADJUST_KEY = "sequence_adjustment_code",
-}
----@param context Context
-function Property.get(context)
-    return context:get_property(Property.ADJUST_KEY)
-end
-
----@param context Context
-function Property.reset(context)
-    local code = Property.get(context)
-    if code ~= nil and code ~= "" then
-        context:set_property(Property.ADJUST_KEY, "")
+--- seq_db start
+local seq_db = {}
+seq_db.db_name = "lua/sequence"
+seq_db._instance = nil
+function seq_db.close()
+    if seq_db._instance and seq_db._instance:loaded() then
+        collectgarbage()
+        seq_db._instance:close()
+        seq_db._instance = nil
     end
 end
 
-local CurrentState = {}
+function seq_db._get()
+    seq_db._instance = seq_db._instance or LevelDb(seq_db.db_name)
+    if seq_db._instance and not seq_db._instance:loaded() then
+        seq_db._instance:open()
+    end
+    return seq_db._instance
+end
+
+local META_KEY_PREFIX = "\001" .. "/"
+local META_KEY_M_VERSION = "migration_version"
+
+function seq_db.update(key, value) return seq_db._get():update(key, value) end
+
+function seq_db.fetch(key) return seq_db._get():fetch(key) end
+
+function seq_db.erase(key) return seq_db._get():erase(key) end
+
+function seq_db.query(prefix) return seq_db._get():query(prefix) end
+
+function seq_db.meta_fetch(key)
+    return seq_db.fetch(META_KEY_PREFIX .. key)
+end
+
+function seq_db.meta_update(key, value)
+    return seq_db.update(META_KEY_PREFIX .. key, value)
+end
+
+function seq_db.get_migration_version()
+    return seq_db.meta_fetch(META_KEY_M_VERSION)
+end
+
+---@param version string
+function seq_db.update_migration_version(version)
+    return seq_db.meta_update(META_KEY_M_VERSION, version)
+end
+
+--- seq_db end
+
+local seq_property = {
+    ADJUST_KEY = "sequence_adjustment_code",
+}
+---@param context Context
+function seq_property.get(context)
+    return context:get_property(seq_property.ADJUST_KEY)
+end
+
+---@param context Context
+function seq_property.reset(context)
+    local code = seq_property.get(context)
+    if code ~= nil and code ~= "" then
+        context:set_property(seq_property.ADJUST_KEY, "")
+    end
+end
+
+local curr_state = {}
 ---@enum AdjustStateMode
-CurrentState.ADJUST_MODE = {
+curr_state.ADJUST_MODE = {
     None = -1,
     Reset = 0,
     Pin = 1,
     Adjust = 2
 }
-CurrentState.default = {
+curr_state.default = {
     ---@type string | nil 当前选中的候选词，用户正常模式排序
     selected_phrase = nil,
     ---@type integer 当前选中的位置索引，用于命令模式排序
     offset = 0,
     ---@type AdjustStateMode 当前调整模式
-    mode = CurrentState.ADJUST_MODE.None,
+    mode = curr_state.ADJUST_MODE.None,
     ---@type integer | nil 当前高亮索引。nil 为初始值
     highlight_index = nil,
     ---@type string | nil 当前的 adjust_code
@@ -44,129 +94,117 @@ CurrentState.default = {
     ---@type string | integer | nil 当前的 adjust_key
     adjust_key = nil,
 }
-function CurrentState.reset()
+function curr_state.reset()
     -- 如果是 nil，则已经是默认值了，不行要重置
-    if not CurrentState.has_adjustment() then return end
+    if not curr_state.has_adjustment() then return end
 
-    for key, value in pairs(CurrentState.default) do
-        CurrentState[key] = value
+    for key, value in pairs(curr_state.default) do
+        curr_state[key] = value
     end
 end
 
-function CurrentState.is_pin_mode()
-    return CurrentState.mode == CurrentState.ADJUST_MODE.Pin
+function curr_state.is_pin_mode()
+    return curr_state.mode == curr_state.ADJUST_MODE.Pin
 end
 
-function CurrentState.is_reset_mode()
-    return CurrentState.mode == CurrentState.ADJUST_MODE.Reset
+function curr_state.is_reset_mode()
+    return curr_state.mode == curr_state.ADJUST_MODE.Reset
 end
 
-function CurrentState.is_adjust_mode()
-    return CurrentState.mode == CurrentState.ADJUST_MODE.Adjust
+function curr_state.is_adjust_mode()
+    return curr_state.mode == curr_state.ADJUST_MODE.Adjust
 end
 
-function CurrentState.has_adjustment()
-    return CurrentState.mode ~= CurrentState.ADJUST_MODE.None
+function curr_state.has_adjustment()
+    return curr_state.mode ~= curr_state.ADJUST_MODE.None
 end
 
-local db_file_name = "lua/sequence"
-local _user_db = nil
--- 获取或创建 LevelDb 实例，避免重复打开
-local function get_user_db()
-    _user_db = _user_db or LevelDb(db_file_name)
-
-    local function close()
-        if _user_db:loaded() then
-            collectgarbage()
-            _user_db:close()
-        end
-    end
-
-    if _user_db and not _user_db:loaded() then
-        _user_db:open()
-    end
-
-    return _user_db, close
-end
-
----@param value string LevelDB 中序列化的值
----@return { fixed_position: integer, offset: integer, updated_at: integer }
-local function parse_adjustment_value(value)
-    local result = {}
-
-    local fixed_position, offset, updated_at = value:match("([-%d]+),?([-%d]*)\t([.%d]+)")
-    result.fixed_position = tonumber(fixed_position);
-    result.offset = offset and tonumber(offset) or 0;
-    result.updated_at = tonumber(updated_at);
-
-    return result
-end
-
----@param code string
----@param adjust_key string | number
-local function get_adjust_db_key(code, adjust_key)
-    if tostring(adjust_key) == "" or code == "" then
-        return nil
-    end
-    return string.format("%s|%s", code, adjust_key)
-end
-
----@param code string 当前输入码
----@return table<string, { fixed_position: integer, offset: integer, updated_at: integer, raw_position?: integer }> | nil
-local function get_adjustments(code)
-    if code == "" or code == nil then return nil end
-
-    local db = get_user_db()
-
-    local accessor = db:query(code .. "|")
-    if accessor == nil then return nil end
-
+---@return table<string, RuntimeAdjustment> | nil
+local function parse_adjustment_value(value_str)
     local adjustment = nil
-    for key, value in accessor:iter() do
+
+    for value in value_str:gmatch("[^\t]+") do
         if adjustment == nil then adjustment = {} end
 
-        local adjust_key = string.match(key, "^.*|(%S+)$")
-        local adjust_value = parse_adjustment_value(value)
+        local item, fixed_position, offset, updated_at = value:match("i=(%S+) p=(%S+) o=(%S+) t=(%S+)")
+        fixed_position = fixed_position and tonumber(fixed_position)
+        offset = offset and tonumber(offset)
+        updated_at = updated_at and tonumber(updated_at)
         -- 忽略为 0 的位置，0 位置代表重置
-        if adjust_value.fixed_position > 0 then
-            adjustment[adjust_key] = adjust_value
+        if fixed_position > 0 then
+            adjustment[item] = {
+                fixed_position = fixed_position,
+                offset = offset,
+                updated_at = updated_at,
+            }
             -- log.warning(string.format("[sequence] %s: %s", adjust_key, value))
         end
     end
 
-    ---@diagnostic disable-next-line: cast-local-type
-    accessor = nil
-
     return adjustment
 end
 
+local adjustments_cache = {
+    key = nil,
+    value = nil,
+}
+---@param input string 当前输入码
+---@return table<string, RuntimeAdjustment> | nil
+local function get_adjustments(input)
+    if adjustments_cache.key == input then return adjustments_cache.value end
+
+    if input == "" or input == nil then return nil end
+
+    local value_str = seq_db.fetch(input)
+    if value_str == nil then return nil end
+
+    local adjustment = parse_adjustment_value(value_str)
+    adjustments_cache.value = adjustment
+    return adjustments_cache.value
+end
+
+-- 由于 lua os.time() 的精度只到秒，排序过快可能会引起问题
 local function get_timestamp()
     return rime_api.get_time_ms
         and os.time() + tonumber(string.format("0.%s", rime_api.get_time_ms()))
         or os.time()
 end
 
----@param code string 匹配的输入码
----@param adjust_key string | number 匹配键，为候选索引（命令模式），或候选词（普通模式）
----@param fixed_position integer `0` 为重置排序，>0 为目标位置
----@param offset? integer | nil
----@param timestamp? number 操作时间戳，默认去当前时间戳
-local function save_adjustment(code, adjust_key, fixed_position, offset, timestamp)
-    if code == "" or code == nil then return end
+---@class Adjustment
+---@field fixed_position integer `0` 为重置，>0 为目标位置
+---@field offset integer 0 表示置顶／重置，<0 前移位数，>0 后移位数
+---@field updated_at number 操作时间戳
 
-    local key = get_adjust_db_key(code, adjust_key)
-    if key == nil then return false end
+---@class RuntimeAdjustment: Adjustment
+---@field raw_position? integer 去重后的原始位置
+---@field from_position? integer 每次应用移动后的当前位置
 
-    local db = get_user_db()
+---@param input string 匹配的输入码
+---@param item string 调整项：命令模式为候选索引，其他为候选词
+---@param adjustment Adjustment
+local function save_adjustment(input, item, adjustment)
+    if input == "" or input == nil then return end
 
-    -- 由于 lua os.time() 的精度只到秒，排序可能会引起问题
-    if not timestamp then
-        timestamp = get_timestamp()
+    local adjustments = get_adjustments(input) or {}
+
+    adjustments[item] = {
+        fixed_position = adjustment.fixed_position,
+        offset = adjustment.offset,
+        updated_at = adjustment.updated_at,
+    }
+
+    local values = {}
+    for key, value in pairs(adjustments) do
+        local value_str = string.format("i=%s p=%s o=%s t=%s", key, value.fixed_position, value.offset, value.updated_at)
+        table.insert(values, value_str)
     end
 
-    local value = string.format("%s,%s\t%s", fixed_position, offset or 0, timestamp)
-    -- log.warning(string.format("[sequence/save_adjustment] %s: %s", key, value, fixed_position))
-    return db:update(key, value)
+    if adjustments_cache.key == input then
+        adjustments_cache.key = nil
+        adjustments_cache.value = nil
+    end
+
+    return seq_db.update(input, table.concat(values, "\t"))
 end
 
 ---从 context 中获取当前排序匹配码
@@ -174,7 +212,7 @@ end
 ---@return string | nil
 local function extract_adjustment_code(context)
     if wanxiang.is_function_mode_active(context) then
-        local code = Property.get(context)
+        local code = seq_property.get(context)
         if code and code ~= "" then
             return code
         end
@@ -184,39 +222,73 @@ local function extract_adjustment_code(context)
     return context.input:sub(1, context.caret_pos)
 end
 
-local sync_file_name = rime_api.get_user_data_dir() .. "/" .. db_file_name .. ".txt"
+local sync_file_name = rime_api.get_user_data_dir() .. "/" .. seq_db.db_name .. ".txt"
 
-local function file_exists(name)
-    local f = io.open(name, "r")
-    if f then
-        io.close(f)
-        return true
+local function db_migration()
+    local migration_version = seq_db.get_migration_version()
+    if migration_version then return end
+
+    local migration_count = 0
+    ---@type nil | DbAccessor
+    local da = nil
+    da = seq_db.query("")
+    if not da then return end
+
+    for old_key, old_value in da:iter() do
+        -- 兼容旧数据
+        local input, item = old_key:match("(%S+)|(%S+)")
+        if input and item then
+            local fixed_position, offset, updated_at = old_value:match("([-%d]+),?([-%d]*)\t([.%d]+)")
+            seq_db.erase(old_key)
+            save_adjustment(input, item, { fixed_position = fixed_position, offset = offset, updated_at = updated_at })
+            migration_count = migration_count + 1
+        end
     end
-    return false
+    da = nil
+
+    seq_db.update_migration_version("8.9.3")
+    if migration_count > 0 then
+        log.info(string.format("[super_sequence] 完成旧格式数据迁移，共 %s 条", migration_count))
+    end
 end
 
-local function export_to_file(db)
+local function export_to_file()
     -- 文件已存在不进行覆盖
-    if file_exists(sync_file_name) then return end
+    if wanxiang.file_exists(sync_file_name) then return end
 
     local file = io.open(sync_file_name, "w")
     if not file then return end;
 
     ---@type nil | DbAccessor
     local da = nil
-    da = db:query("")
+    da = seq_db.query("")
     if not da then return end
 
     for key, value in da:iter() do
-        local line = string.format("%s\t%s", key, value)
-        local from_user_id = string.match(line, "^" .. "\001" .. "/user_id\t(.+)")
-        if from_user_id ~= nil then
-            local fixed_user_id = wanxiang.get_user_id()
-            if fixed_user_id ~= from_user_id then
-                line = "\001" .. "/user_id\t" .. fixed_user_id
+        -- 兼容旧数据
+        local input, item = key:match("(%S+)|(%S+)")
+        if input and item then
+            key = input
+            local fixed_position, offset, updated_at = value:match("([-%d]+),?([-%d]*)\t([.%d]+)")
+            value = string.format("i=%s p=%s o=%s t=%s", item, fixed_position, offset, updated_at)
+        end
+
+        if key:sub(1, 2) == "\001" .. "/" then
+            local line = string.format("%s\t%s", key, value)
+            local from_user_id = string.match(line, "^" .. "\001" .. "/user_id\t(.+)")
+            if from_user_id ~= nil then
+                local fixed_user_id = wanxiang.get_user_id()
+                if fixed_user_id ~= from_user_id then
+                    line = "\001" .. "/user_id\t" .. fixed_user_id
+                end
+            end
+            file:write(line, "\n")
+        else
+            for adj_str in value:gmatch("[^\t]+") do
+                local line = string.format("%s\t%s", key, adj_str)
+                file:write(line, "\n")
             end
         end
-        file:write(line, "\n")
     end
     da = nil
 
@@ -225,7 +297,7 @@ local function export_to_file(db)
     file:close()
 end
 
-local function import_from_file(db)
+local function import_from_file()
     local file = io.open(sync_file_name, "r")
     if not file then return end;
 
@@ -246,21 +318,29 @@ local function import_from_file(db)
         if line:sub(1, 2) == "\001" .. "/" then goto continue end
 
         -- 以下开始处理输入
-        local key, value = string.match(line, "^(.-)\t(.+)$")
+        local input, value = line:match("^(%S+)\t(%S+)$")
 
-        if key and value then
-            local code, phrase = string.match(key, "^(.+)|(.+)$")
-            local info = parse_adjustment_value(value)
-            local exist_value = db:fetch(key)
-            if exist_value then -- 跳过旧的数据
-                local exist_info = parse_adjustment_value(exist_value)
-                if info.updated_at <= exist_info.updated_at then
+        if input and value then
+            local old_input, item = input:match("^(.+)|(.+)$")
+            if old_input and item then
+                input = old_input
+                local fixed_position, offset, updated_at = value:match("([-%d]+),?([-%d]*)\t([.%d]+)")
+                value = string.format("i=%s p=%s o=%s t=%s", item, fixed_position, offset, updated_at)
+            end
+
+            local from_adjustment = parse_adjustment_value(value)
+            if not from_adjustment then goto continue end
+
+            local exist_adjustments = get_adjustments(input)
+            local exist_adjustment  = exist_adjustments and exist_adjustments[from_adjustment.item] or nil
+            if exist_adjustment then -- 跳过旧的数据
+                if from_adjustment.updated_at <= exist_adjustment.updated_at then
                     goto continue
                 end
             end
 
             import_count = import_count + 1
-            save_adjustment(code, phrase, info.fixed_position, info.offset, info.updated_at)
+            save_adjustment(input, item, from_adjustment)
         end
 
         ::continue::
@@ -274,37 +354,25 @@ local function import_from_file(db)
     end
 end
 
+local P = {}
+function P.init()
+    db_migration()
+    import_from_file()
+end
+
 ---执行排序调整
 ---@param context Context
 local function process_adjustment(context)
     local selected_cand = context:get_selected_candidate()
-    CurrentState.selected_phrase = selected_cand.text
+    curr_state.selected_phrase = selected_cand.text
 
     context:refresh_non_confirmed_composition()
 
     if context.highlight
-        and CurrentState.highlight_index
-        and CurrentState.highlight_index > 0 then
-        context:highlight(CurrentState.highlight_index)
+        and curr_state.highlight_index
+        and curr_state.highlight_index > 0 then
+        context:highlight(curr_state.highlight_index)
     end
-end
-
----当前 context 是否允许自定义排序
----@param context Context
----@return boolean
-local function is_adjustment_allowed(context)
-    if wanxiang.is_function_mode_active(context) -- function mode 必须有设置 sequence_adjustment_code
-        and Property.get(context) == nil then
-        return false
-    end
-
-    return true
-end
-
-local P = {}
-function P.init()
-    local db = get_user_db()
-    import_from_file(db)
 end
 
 -- P 阶段按键处理
@@ -314,8 +382,8 @@ end
 function P.func(key_event, env)
     local context = env.engine.context
     ---重置状态
-    Property.reset(context)
-    CurrentState.reset()
+    seq_property.reset(context)
+    curr_state.reset()
 
     local selected_cand = context:get_selected_candidate()
 
@@ -330,17 +398,17 @@ function P.func(key_event, env)
 
     -- 判断按下的键，更新偏移量
     if key_event.keycode == 0x6A then -- 前移
-        CurrentState.offset = -1
-        CurrentState.mode = CurrentState.ADJUST_MODE.Adjust
+        curr_state.offset = -1
+        curr_state.mode = curr_state.ADJUST_MODE.Adjust
     elseif key_event.keycode == 0x6B then -- 后移
-        CurrentState.offset = 1
-        CurrentState.mode = CurrentState.ADJUST_MODE.Adjust
+        curr_state.offset = 1
+        curr_state.mode = curr_state.ADJUST_MODE.Adjust
     elseif key_event.keycode == 0x6C then -- 重置
-        CurrentState.offset = nil
-        CurrentState.mode = CurrentState.ADJUST_MODE.Reset
+        curr_state.offset = nil
+        curr_state.mode = curr_state.ADJUST_MODE.Reset
     elseif key_event.keycode == 0x70 then -- 置顶
-        CurrentState.offset = nil
-        CurrentState.mode = CurrentState.ADJUST_MODE.Pin
+        curr_state.offset = nil
+        curr_state.mode = curr_state.ADJUST_MODE.Pin
     else
         return wanxiang.RIME_PROCESS_RESULTS.kNoop
     end
@@ -354,9 +422,8 @@ local F = {}
 function F.init() end
 
 function F.fini()
-    local db, db_close = get_user_db()
-    export_to_file(db)
-    db_close()
+    export_to_file()
+    seq_db.close()
 end
 
 ---应用之前的调整
@@ -417,7 +484,7 @@ local function apply_curr_adjustment(candidates, curr_adjustment)
     ---@type integer | nil
     local from_position = nil
     for position, cand in ipairs(candidates) do
-        if cand.text == CurrentState.selected_phrase then
+        if cand.text == curr_state.selected_phrase then
             from_position = position
             break
         end
@@ -426,8 +493,8 @@ local function apply_curr_adjustment(candidates, curr_adjustment)
     if from_position == nil then return end
 
     local to_position = from_position
-    if CurrentState.is_adjust_mode() then
-        to_position = from_position + CurrentState.offset
+    if curr_state.is_adjust_mode() then
+        to_position = from_position + curr_state.offset
         curr_adjustment.offset = to_position - curr_adjustment.raw_position
         curr_adjustment.fixed_position = to_position
 
@@ -442,12 +509,23 @@ local function apply_curr_adjustment(candidates, curr_adjustment)
             local candidate = table.remove(candidates, from_position)
             table.insert(candidates, to_position, candidate)
 
-            save_adjustment(CurrentState.adjust_code, CurrentState.adjust_key,
-                curr_adjustment.fixed_position, curr_adjustment.offset, curr_adjustment.updated_at)
+            save_adjustment(curr_state.adjust_code, curr_state.adjust_key, curr_adjustment)
         end
     end
 
-    CurrentState.highlight_index = to_position - 1
+    curr_state.highlight_index = to_position - 1
+end
+
+---当前 context 是否允许自定义排序
+---@param context Context
+---@return boolean
+local function is_adjustment_allowed(context)
+    if wanxiang.is_function_mode_active(context) -- function mode 必须有设置 sequence_adjustment_code
+        and seq_property.get(context) == nil then
+        return false
+    end
+
+    return true
 end
 
 ---@param input Translation
@@ -472,9 +550,12 @@ function F.func(input, env)
 
     local prev_adjustments = get_adjustments(adjust_code)
 
+    ---@type RuntimeAdjustment | nil
     local curr_adjustment = nil
-    if CurrentState.has_adjustment() then
+    if curr_state.has_adjustment() then
         curr_adjustment = {
+            fixed_position = 0,
+            offset = 0,
             updated_at = get_timestamp(),
         }
     end
@@ -501,19 +582,18 @@ function F.func(input, env)
             table.insert(candidates, candidate)
 
             local curr_key = is_function_mode_active
-                and position - 1 -- function mode 使用索引模式
+                and tostring(position - 1) -- function mode 使用索引模式
                 or phrase
-            local curr_key_str = tostring(curr_key)
 
-            if curr_adjustment ~= nil and CurrentState.selected_phrase == phrase then
-                CurrentState.adjust_code = adjust_code
-                CurrentState.adjust_key = curr_key
+            if curr_adjustment ~= nil and curr_state.selected_phrase == phrase then
+                curr_state.adjust_code = adjust_code
+                curr_state.adjust_key = curr_key
 
                 curr_adjustment.raw_position = position
             end
 
-            if prev_adjustments and prev_adjustments[curr_key_str] ~= nil then
-                prev_adjustments[curr_key_str].raw_position = position -- raw_position 记录原始顺序
+            if prev_adjustments and prev_adjustments[curr_key] ~= nil then
+                prev_adjustments[curr_key].raw_position = position -- raw_position 记录原始顺序
             end
         end
     end
@@ -521,20 +601,19 @@ function F.func(input, env)
     prev_adjustments = prev_adjustments or {}
 
     -- 提前处理置顶/重置操作，以简化逻辑
-    if curr_adjustment ~= nil and not CurrentState.is_adjust_mode() then
+    if curr_adjustment ~= nil and not curr_state.is_adjust_mode() then
         curr_adjustment.offset = 0
 
-        local key = tostring(CurrentState.adjust_key)
-        if CurrentState.is_reset_mode() then -- reset mode 提前清空之前的旧数据
+        local key = tostring(curr_state.adjust_key)
+        if curr_state.is_reset_mode() then -- reset mode 提前清空之前的旧数据
             curr_adjustment.fixed_position = 0
             prev_adjustments[key] = nil
-        elseif CurrentState.is_pin_mode() then
+        elseif curr_state.is_pin_mode() then
             curr_adjustment.fixed_position = 1
             prev_adjustments[key] = curr_adjustment
         end
 
-        save_adjustment(CurrentState.adjust_code, CurrentState.adjust_key,
-            curr_adjustment.fixed_position, curr_adjustment.offset, curr_adjustment.updated_at)
+        save_adjustment(curr_state.adjust_code, curr_state.adjust_key, curr_adjustment)
     end
 
     apply_prev_adjustment(candidates, prev_adjustments)


### PR DESCRIPTION
- 通过让每次查询 sequence db 使用 `fetch` 而不是 `query` 来提高性能
- 对新版排序以来的两次数据结构做了兼容，部署时会自动迁移旧数据到新格式

新的数据结构见下。其中：

- 排序项：普通模式为「候选词」，功能模式为「候选索引」（从 0  开始计算）
- 位置：
  - 重置为 `0`
  - 置顶为 `1`
  - 其他值为移动后的位置。（此种情况只做记录，实际排序按偏移量计算）
- 偏移量：前／后移动的偏移量
  - 前移 `<0`
  - 后移 `>0`
  - 「重置」、「置顶」等非前／后移操作为 `0`

```console
  制表符分割
      |        空格分割
      |            |
      v            v
 /rq	i=2 p=1 o=0 t=1752737077.5417
 vuvj	i=主站 p=1 o=0 t=1752737072.5412
  ^        ^     ^   ^          ^
  |        |     |   |          |
输入码   排序项  | 偏移量     时间戳
                 |
                位置
```
--- 

功能已完成，仍需完整的测试