### PR TITLE
feat(sequence): 手动排序支持绑定自定义快捷键

### DIFF
--- a/lua/super_sequence.lua
+++ b/lua/super_sequence.lua
@@ -6,6 +6,13 @@
 -- ctrl+p 置顶
 local wanxiang = require("wanxiang")
 
+local DEFAULT_SEQ_KEY = {
+    up    = "Control+j",
+    down  = "Control+k",
+    reset = "Control+l",
+    pin   = "Control+p",
+}
+
 --- seq_db start
 local seq_db = {}
 seq_db.db_name = "lua/sequence"
@@ -390,23 +397,28 @@ function P.func(key_event, env)
     if not context:has_menu()
         or selected_cand == nil
         or selected_cand.text == nil
-        or not key_event:ctrl()
-        or key_event:release()
     then
         return wanxiang.RIME_PROCESS_RESULTS.kNoop
     end
 
     -- 判断按下的键，更新偏移量
-    if key_event.keycode == 0x6A then -- 前移
+    local key_repr = key_event:repr()
+
+    local function get_seq_key(type)
+        return env.engine.schema.config:get_string("key_binder/sequence/" .. type)
+            or DEFAULT_SEQ_KEY[type]
+    end
+
+    if key_repr == get_seq_key("up") then -- 前移
         curr_state.offset = -1
         curr_state.mode = curr_state.ADJUST_MODE.Adjust
-    elseif key_event.keycode == 0x6B then -- 后移
+    elseif key_repr == get_seq_key("down") then -- 后移
         curr_state.offset = 1
         curr_state.mode = curr_state.ADJUST_MODE.Adjust
-    elseif key_event.keycode == 0x6C then -- 重置
+    elseif key_repr == get_seq_key("reset") then -- 重置
         curr_state.offset = nil
         curr_state.mode = curr_state.ADJUST_MODE.Reset
-    elseif key_event.keycode == 0x70 then -- 置顶
+    elseif key_repr == get_seq_key("pin") then -- 置顶
         curr_state.offset = nil
         curr_state.mode = curr_state.ADJUST_MODE.Pin
     else

--- a/wanxiang.schema.yaml
+++ b/wanxiang.schema.yaml
@@ -345,6 +345,11 @@ punctuator:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
+  sequence: # Lua 配置：手动排序的快捷键 super_sequence.lua
+    up: "Control+j"    # 上移
+    down: "Control+k"  # 下移
+    reset: "Control+l" # 重置
+    pin: "Control+p"   # 置顶
   # Lua 配置: shijian.lua 的引导符，涉及：日期、时间、节日、节气、生日、问候模板等功能
   shijian_keys: ["/", "o"]
   # Lua 配置: 超级tips上屏按键

--- a/wanxiang_pro.schema.yaml
+++ b/wanxiang_pro.schema.yaml
@@ -354,6 +354,11 @@ punctuator:
 # 从 default 继承快捷键
 key_binder:
   import_preset: default  # 从 default.yaml 继承通用的
+  sequence: # Lua 配置：手动排序的快捷键 super_sequence.lua
+    up: "Control+j"    # 上移
+    down: "Control+k"  # 下移
+    reset: "Control+l" # 重置
+    pin: "Control+p"   # 置顶
   # Lua 配置: shijian.lua 的引导符，涉及：日期、时间、节日、节气、生日、问候模板等功能
   shijian_keys: ["/", "o"]
   # Lua 配置: 超级tips上屏按键


### PR DESCRIPTION
有这个需求的用户应该不少，我也受此问题困扰，我日常使用频次很高的软件
VSCode，在打开 Terminal 时，输入中使用 Ctrl L 就会导致 Terminal
窗口最小化，从而导致候选焦点切换到编辑区域，诸如此类的问题，每个人的
日常使用场景不一样，的确很难一套快捷键适配所有，给到用户自定义的选项，
会避免用户手动修改 lua 代码，导致后续更新困难。