### PR TITLE
fix(lua): 保持与 Lua 5.1 的兼容性

### DIFF
--- a/lua/super_calculator.lua
+++ b/lua/super_calculator.lua
@@ -2421,7 +2421,7 @@ local function prime_factorization(n)
     -- 处理2的因子
     while n % 2 == 0 do
         factors[2] = (factors[2] or 0) + 1
-        n = n // 2
+        n = math.floor(n / 2)
     end
     -- 处理奇数因子
     local divisor = 3
@@ -2429,7 +2429,7 @@ local function prime_factorization(n)
     while divisor <= max_divisor and n > 1 do
         while n % divisor == 0 do
             factors[divisor] = (factors[divisor] or 0) + 1
-            n = n // divisor
+            n = math.floor(n / divisor)
             max_divisor = math.floor(math.sqrt(n))
         end
         divisor = divisor + 2


### PR DESCRIPTION
LuaJIT 的 Lua 版本为 5.1, 此修复保证了与 LuaJIT 的兼容性

see: https://github.com/LuaJIT/LuaJIT/issues/1092