### PR TITLE
fix: 超级提示 disabled type 匹配由排除集合改成非贪婪模式,修复"化学式"类型无法排除的问题

### DIFF
--- a/lua/super_tips.lua
+++ b/lua/super_tips.lua
@@ -54,8 +54,8 @@ local META_KEY = {
 
 ---@param tip string
 function tips.is_disabled(tip)
-    local type = tip:match("^([^:]+):")
-        or tip:match("^([^：]+)：")
+    local type = tip:match("^(..-):")
+        or tip:match("^(..-)：")
 
     if not type then return false end
     return tips.disabled_types[type] == true


### PR DESCRIPTION
fix #434 