### PR TITLE
适配iOS端元书输入法

### DIFF
--- a/lua/super_tips.lua
+++ b/lua/super_tips.lua
@@ -95,7 +95,7 @@ function tips.init(config)
 
     local dist = rime_api.get_distribution_code_name() or ""
     local user_lua_dir = rime_api.get_user_data_dir() .. "/lua"
-    if dist ~= "hamster" and dist ~= "Weasel" then
+    if dist ~= "hamster" and dist ~= "hamster3" and dist ~= "Weasel" then
         tips.ensure_dir_exist(user_lua_dir)
         tips.ensure_dir_exist(user_lua_dir .. "/tips")
     end

--- a/lua/wanxiang.lua
+++ b/lua/wanxiang.lua
@@ -34,6 +34,7 @@ function wanxiang.is_mobile_device()
         -- 主判断：常见移动端输入法
         if lower_dist == "trime" or
             lower_dist == "hamster" or
+            lower_dist == "hamster3" or
             lower_dist == "squirrel" then
             return true
         end


### PR DESCRIPTION
添加元书输入法的`distribution_code_name`和`distribution_name`以便rime正常获取