### PR TITLE
调整人名词库

### DIFF
--- a/wanxiang_people.dict.yaml
+++ b/wanxiang_people.dict.yaml
@@ -29339,8 +29339,6 @@ sort: by_weight
 吴恩达	wú'ēn'dá
 吴恩琪	wú'ēn'qí
 吴恩韶	wú'ēn'sháo
-吴二人	wú'èr'rén
-吴伐楚	wú'fá'chǔ
 吴法鼎	wú'fǎ'dǐng
 吴法天	wú'fǎ'tiān
 吴法宪	wú'fǎ'xiàn
@@ -29370,7 +29368,6 @@ sort: by_weight
 吴甘沙	wú'gān'shā
 吴高俊	wú'gāo'jùn
 吴高龙	wú'gāo'lóng
-吴哥城	wú'gē'chéng
 吴哥哥	wú'gē'ge
 吴哥寺	wú'gē'sì
 吴耕民	wú'gēng'mín
@@ -29403,7 +29400,6 @@ sort: by_weight
 吴桂贤	wú'guì'xián
 吴桂英	wú'guì'yīng
 吴国安	wú'guó'ān
-吴国大	wú'guó'dà
 吴国栋	wú'guó'dòng
 吴国对	wú'guó'duì
 吴国芳	wú'guó'fāng
@@ -29663,7 +29659,6 @@ sort: by_weight
 吴金玉	wú'jīn'yù
 吴锦源	wú'jǐn'yuán
 吴京安	wú'jīng'ān
-吴京吧	wú'jīng'ba
 吴景彪	wú'jǐng'biāo
 吴景伯	wú'jǐng'bó
 吴劲草	wú'jìng'cǎo
@@ -29726,7 +29721,6 @@ sort: by_weight
 吴俊霆	wú'jùn'tíng
 吴俊伟	wú'jùn'wěi
 吴俊纬	wú'jùn'wěi
-吴郡吴	wú'jùn'wú
 吴俊贤	wú'jùn'xián
 吴俊雄	wú'jùn'xióng
 吴俊谚	wú'jùn'yàn
@@ -29817,7 +29811,6 @@ sort: by_weight
 吴美仙	wú'měi'xiān
 吴玫颖	wú'méi'yǐng
 吴美枝	wú'měi'zhī
-吴门派	wú'mén'pài
 吴门桥	wú'mén'qiáo
 吴蒙庵	wú'méng'ān
 吴梦非	wú'mèng'fēi
@@ -29912,7 +29905,6 @@ sort: by_weight
 吴奇伟	wú'qí'wěi
 吴启洋	wú'qǐ'yáng
 吴其轺	wú'qí'yáo
-吴起在	wú'qǐ'zài
 吴仟峰	wú'qiān'fēng
 吴倩莲	wú'qiàn'lián
 吴千能	wú'qiān'néng


### PR DESCRIPTION
看人名模式正式进了release，参考 [这里的讨论](https://github.com/amzxyz/rime_wanxiang/issues/49#issuecomment-3445995018)，主要将 [#comment](https://github.com/amzxyz/rime_wanxiang/issues/49#issuecomment-3445989269) 中归类为`重要`的人名和非人名移至`base.dict.yaml`，删除了`建议删除`部分的词条，其他人名待定。
如有问题可直接编辑pr。