### PR TITLE
fix(lua): 修复小键盘数字在commit_text时导致PSReadLine的bug

### DIFF
--- a/lua/kp_number_processor.lua
+++ b/lua/kp_number_processor.lua
@@ -120,7 +120,7 @@ function P.func(key, env)
                 if context.push_input then context:push_input(ch)
                 else context.input = (context.input or "") .. ch end
             else
-                env.engine:commit_text(ch)
+                return wanxiang.RIME_PROCESS_RESULTS.kNoop
             end
         else -- compose
             if context.push_input then context:push_input(ch)


### PR DESCRIPTION
在 VSCode 的 PowerShell 终端连续输入小键盘的数字出现的情形：
![PixPin_2026-01-17_01-54-59](https://github.com/user-attachments/assets/7808a494-5fe4-4558-982c-bd80e7dd2d8a)
powershell配置：
```
oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/atomic.omp.json" | Invoke-Expression
Set-PSReadLineOption -PredictionSource History
Set-PSReadLineOption -PredictionViewStyle ListView
Set-PSReadLineOption -EditMode Windows
```

> 当小键盘模式为 auto 且当前没有在输入编码（env.is_composing 为 false）时，脚本使用了 env.engine:commit_text(ch) 来直接上屏数字。
> 在 VSCode 的 PowerShell 终端（以及其他一些使用 PSReadLine 的终端环境）中，通过 IME commit_text 上屏的字符有时会被视为“粘贴”或特殊的文本块输入，而不是普通的按键输入。这可能会干扰 PSReadLine 的输入处理逻辑，导致它错误地触发历史记录搜索、预测列表显示或其他异常行为。

>  修改 kp_number_processor.lua，在非编码状态下，不再手动 commit_text，而是返回 kNoop。这样 Rime 会忽略该按键，将其交给操作系统和终端处理。终端接收到原始的小键盘按键事件后，会将其作为标准输入处理，从而避免 PSReadLine 的异常。

靠Gemini帮忙改的，改完可以了。不知道这样改行不行...