### PR TITLE
fix: 兼容 Lua 5.5 只读局部变量语义

### DIFF
--- a/lua/wanxiang/super_english.lua
+++ b/lua/wanxiang/super_english.lua
@@ -163,6 +163,7 @@ local function apply_segment_formatting(text, input_code)
     local parts = {}
     local p_code = 1 
     for word in string.gmatch(text, "%S+") do
+        local out_word = word
         local clean_word = pure(word)
         local w_len = #clean_word
         if w_len > 0 then
@@ -179,15 +180,15 @@ local function apply_segment_formatting(text, input_code)
                     local segment = sub(input_code, p_code, p_code + check_len - 1)
                     local is_pure_alpha = not find(word, "[^a-zA-Z]")
                     if find(segment, "^%u%u") and is_pure_alpha then
-                        word = upper(word)
+                        out_word = upper(word)
                     elseif find(segment, "^%u") then
-                        word = gsub(word, "^%a", upper)
+                        out_word = gsub(word, "^%a", upper)
                     end
                     p_code = p_code + check_len
                 end
             end
         end
-        table.insert(parts, word)
+        table.insert(parts, out_word)
     end
     return table.concat(parts, " ")
 end

--- a/lua/wanxiang/super_sequence.lua
+++ b/lua/wanxiang/super_sequence.lua
@@ -100,8 +100,8 @@ local function _read_installation_yaml()
     local f = io.open(path, "r"); if not f then return nil, nil end
     local installation_id, sync_dir
     for line in f:lines() do
-        line = line:gsub("%s+#.*$", "")
-        local key, val = line:match("^%s*([%w_]+)%s*:%s*(.+)$")
+        local cleaned = line:gsub("%s+#.*$", "")
+        local key, val = cleaned:match("^%s*([%w_]+)%s*:%s*(.+)$")
         if key and val then
             val = val:gsub('^%s*"(.*)"%s*$', "%1"):gsub("^%s*'(.*)'%s*$", "%1")
             val = val:gsub("^%s+", ""):gsub("%s+$", "")


### PR DESCRIPTION
## 问题
Rime 将他们的 Lua 引擎版本更新到了 `librime-lua 5.5`。

在 Lua 5.5 下，[`for` 循环控制变量变为只读变量](https://www.lua.org/manual/5.5/manual.html#8)。原有写法会在执行脚本时报错，例如：

```
attempt to assign to const variable 'line'
```

导致万象拼音无法正常加载。

---

本 PR 修改了以下文件中的变量赋值方式：
- `lua/wanxiang/super_sequence.lua`
- `lua/wanxiang/super_english.lua`
具体做法是保留原有逻辑，但不再直接改写 `for` 循环变量，而是改为写入新的局部变量。