### PR TITLE
Disable firefox.exe inline preedit setting

### DIFF
--- a/weasel.yaml
+++ b/weasel.yaml
@@ -19,8 +19,8 @@ app_options:
     ascii_mode: true     # 英文模式
   7zFM.exe:
     ascii_mode: true     # 英文模式
-  firefox.exe:
-    inline_preedit: true # 行内显示预编辑区：规避 <https://github.com/rime/weasel/issues/946>
+  # firefox.exe:
+  #   inline_preedit: true # 行内显示预编辑区：规避 <https://github.com/rime/weasel/issues/946>
   # cmd.exe:               
   #   ascii_mode: true     # 英文模式
   # conhost.exe:


### PR DESCRIPTION
Comment out firefox.exe configuration in weasel.yaml
最新版的小狼毫貌似已经没有这个[问题](https://github.com/rime/weasel/issues/946)，inline_preedit 设置成 true 有时候反而会有问题🤔
