### PR TITLE
反查词库拆分兼容

### DIFF
--- a/wanxiang_reverse.dict.yaml
+++ b/wanxiang_reverse.dict.yaml
@@ -144468,6 +144468,10 @@ sort: original
 𠞀	xue'dao
 𠟶	ku'dao
 𠫓	heng'si
+𠫓	er'si
+𠫓	tou'si
+𠫓	wen'si
+𠫓	yi'si
 𠫮	si'ji
 𠫮	si'ri'ji
 𠳶	kou'tu
@@ -249850,6 +249854,7 @@ sort: original
 𠞀	NNZPNZSSZSSS
 𠟶	NNZPNZHPZSSZSSS
 𠫓	HZN
+𠫓	NHZN
 𠫮	ZNSZHHPZ
 𠳶	SZHPHSPNPZ
 𠸂	SZHNNZPNHPNN


### PR DESCRIPTION
为reverse.dict里的“𠫓”字兼容kIRG_GSource（中国源）、kIRG_TSource（中国台湾源）和kIRG_JSource（日本源）里不同字形的拆法