### PR TITLE
修复: 九宫格续写时按数字键漏字面数字

### DIFF
--- a/lua/wanxiang/user_predict.lua
+++ b/lua/wanxiang/user_predict.lua
@@ -28,6 +28,7 @@ local tonumber = tonumber
 local math_max = math.max
 local math_min = math.min
 local os_time  = os.time
+local wanxiang = require("wanxiang/wanxiang")
 local shared_reverted_code = ""
 local shared_is_backspacing = false
 -- 内部运行参数默认值 (会被外部 YAML 配置覆盖)
@@ -337,6 +338,10 @@ end
 local P = {}
 function P.init(env)
     load_config(env) 
+    env.is_t9 = false
+    if wanxiang.get_input_method_type then
+        env.is_t9 = (wanxiang.get_input_method_type(env) == "t9")
+    end
     local db = get_db(env)
     local now = os_time()
     local CLEAN_INTERVAL = 259200  --3天
@@ -739,6 +744,14 @@ function P.func(key, env)
 
         -- 根据选词范围分流数字键
         if s_match(repr, "^[0-9]$") or s_match(repr, "^KP_[0-9]$") then
+            -- 九宫格(T9): 数字键是音节编码, 续写时放行给 speller 起新音节。
+            if env.is_t9 then
+                env.engine.context:clear()
+                if reset_memory_chain then
+                    reset_memory_chain(env, "T9数字放行起音节")
+                end
+                return 2
+            end
             local digit = s_match(repr, "%d")
             local d = tonumber(digit)
             if d == 0 then d = 10 end


### PR DESCRIPTION
## 问题
九宫格(wanxiang_t9)开启续写后, 如果先上屏一个词, 随后出现续写候选, 此时继续输入下一个音节的首位数字键, 可能会把数字直接上屏。

## 复现
1. 开启 wanxiang_t9 和续写。
2. 先连续输入并上屏「你」「好」, 让用户预测记录形成「你 → 好」。
3. 再输入「你」并上屏, 此时续写候选弹出「好」。
4. 按 9, 想继续输入「样」(yang=9264) 的首键。
5. 实际结果出现「你9」; 期望结果是 9 交给 speller, 作为新音节编码继续输入。

## 原因
续写状态下的数字键分支会先按候选序号处理。若命中 `d > page_size or not is_valid_candidate`, 会执行 `env.engine:commit_text(digit)`, 把数字当字面内容提交。

全拼/双拼里数字键可以作为数字或选词键, 这个逻辑没问题; 但九宫格里 2-9 是编码键, 所以会漏出字面数字。

## 修复
沿用 super_processor 的 get_input_method_type 判断 T9。T9 下遇到续写状态的数字键时, 先清掉续写预测并返回 kNoop, 让 speller 接手这个数字并重新组成下一个音节; 非 T9 逻辑保持不变。

## 验证
已在 Android/Trime 的 wanxiang_t9 + 续写开启场景复现并验证。