### PR TITLE
fix: recognize Cobra as a special desktop environment

### DIFF
--- a/lua/wanxiang/wanxiang.lua
+++ b/lua/wanxiang/wanxiang.lua
@@ -70,7 +70,7 @@ end
 
 local is_special_desktop = nil
 
---- 判断是否为需要特殊处理的桌面环境（squirrel 或 fcitx5-rime+library）
+--- 判断是否为需要特殊处理的桌面环境（squirrel、Cobra 或 fcitx-rime+library）
 ---@return boolean
 function wanxiang.is_special_desktop()
     if is_special_desktop == nil then
@@ -80,7 +80,7 @@ function wanxiang.is_special_desktop()
         local lower_sys = sys_dir:lower()
 
         local exclude = false
-        if lower_dist == "squirrel" then
+        if lower_dist == "squirrel" or lower_dist == "cobra" then
             exclude = true
         elseif lower_dist == "fcitx-rime" and lower_sys:find("library") then
             exclude = true


### PR DESCRIPTION
## 问题

在 macOS 的元书输入法（Cobra）中，连续退格清空编码后，Backspace 可能被 `super_processor` 的退格限制持续拦截，必须切换输入法才能恢复。

Cobra 向 Rime 报告的 `distribution_code_name` 为 `Cobra`，但 `is_special_desktop()` 原先只识别鼠须管（`squirrel`）和对应的 `fcitx-rime` 环境，因此 Cobra 会错误进入退格限制分支。

## 修改

- 将 `cobra` 加入特殊桌面环境判断
- 更新对应注释

这样 Cobra 会和鼠须管一样跳过可能吞掉 Backspace 的保护逻辑。