### PR TITLE
修复 openSUSE 下调用 rime_api.regex_match 导致 Fcitx5 崩溃的问题

### DIFF
--- a/lua/wanxiang/key_binder.lua
+++ b/lua/wanxiang/key_binder.lua
@@ -164,11 +164,17 @@ local function parse(value)
 
     local match_pattern = match and match:get_string() or nil
     local matcher = nil
-    if match_pattern then
+
+    if match_pattern ~= nil then
         local err = nil
         matcher, err = wanxiang.compile_regex(match_pattern)
         if not matcher then
-            log.error("failed to compile key binding pattern: " .. tostring(err))
+            log.error(
+                "failed to compile key binding pattern '"
+                .. tostring(match_pattern)
+                .. "': "
+                .. tostring(err)
+            )
             return nil
         end
     end

--- a/lua/wanxiang/key_binder.lua
+++ b/lua/wanxiang/key_binder.lua
@@ -12,6 +12,7 @@ local this = {}
 
 ---@class Binding
 ---@field match string|nil
+---@field matcher WanxiangRegexMatcher|nil
 ---@field accept KeyEvent|nil
 ---@field actions SequenceAction[]
 
@@ -161,8 +162,20 @@ local function parse(value)
         return nil
     end
 
+    local match_pattern = match and match:get_string() or nil
+    local matcher = nil
+    if match_pattern then
+        local err = nil
+        matcher, err = wanxiang.compile_regex(match_pattern)
+        if not matcher then
+            log.error("failed to compile key binding pattern: " .. tostring(err))
+            return nil
+        end
+    end
+
     return {
-        match = match and match:get_string() or nil,
+        match = match_pattern,
+        matcher = matcher,
         accept = accept and KeyEvent(accept:get_string()) or nil,
         actions = actions,
     }
@@ -282,7 +295,7 @@ function this.func(key_event, env)
 
         local match_ok =
             binding.match == nil
-            or rime_api.regex_match(input, binding.match)
+            or wanxiang.regex_matches(binding.matcher, input)
 
         if key_ok and match_ok then
             env.redirecting = true

--- a/lua/wanxiang/super_processor.lua
+++ b/lua/wanxiang/super_processor.lua
@@ -128,7 +128,7 @@ local function ulen(s)
     return #s
 end
 
--- 直接读取 Rime recognizer 的原生正则，不再转换为 Lua Pattern。
+-- 初始化时编译并缓存 recognizer 正则，热路径只执行匹配。
 local function load_rime_regex_patterns(config, path)
     local patterns, seen = {}, {}
     local map = config and config:get_map(path)
@@ -141,11 +141,12 @@ local function load_rime_regex_patterns(config, path)
         local value = map:get_value(keys[i])
         local regex = value and value.value
         if type(regex) == "string" and regex ~= "" and not seen[regex] then
-            -- 初始化时只编译验证一次；运行时直接走 rime_api.regex_match。
-            local ok = pcall(rime_api.regex_match, "", regex)
-            if ok then
+            local matcher, err = wanxiang.compile_regex(regex)
+            if matcher then
                 seen[regex] = true
-                patterns[#patterns + 1] = regex
+                patterns[#patterns + 1] = matcher
+            else
+                log.error("failed to compile recognizer pattern: " .. tostring(err))
             end
         end
     end
@@ -155,11 +156,11 @@ end
 -- 检查数字后是否紧跟功能编码 (KpNumber 使用)
 local function is_function_code_after_digit(env, context, digit_char)
     if not context or not digit_char or digit_char == "" then return false end
-    local s = (context.input or "") .. digit_char
-    local pats = env.kp_func_patterns
-    if not pats then return false end
-    for _, pat in ipairs(pats) do
-        if rime_api.regex_match(s, pat) then return true end
+    local input = (context.input or "") .. digit_char
+    local patterns = env.kp_func_patterns
+    if not patterns then return false end
+    for _, matcher in ipairs(patterns) do
+        if wanxiang.regex_matches(matcher, input) then return true end
     end
     return false
 end

--- a/lua/wanxiang/super_processor.lua
+++ b/lua/wanxiang/super_processor.lua
@@ -128,14 +128,14 @@ local function ulen(s)
     return #s
 end
 
--- 初始化时编译并缓存 recognizer 正则，热路径只执行匹配。
-local function load_rime_regex_patterns(config, path)
-    local patterns, seen = {}, {}
+-- 初始化时编译并缓存 Rime recognizer 正则；热路径只执行已编译匹配。
+local function load_rime_regex_matchers(config, path)
+    local matchers, seen = {}, {}
     local map = config and config:get_map(path)
-    if not map then return patterns end
+    if not map then return matchers end
 
     local keys = map:keys()
-    if not keys then return patterns end
+    if not keys then return matchers end
 
     for i = 1, #keys do
         local value = map:get_value(keys[i])
@@ -144,24 +144,36 @@ local function load_rime_regex_patterns(config, path)
             local matcher, err = wanxiang.compile_regex(regex)
             if matcher then
                 seen[regex] = true
-                patterns[#patterns + 1] = matcher
+                matchers[#matchers + 1] = matcher
             else
-                log.error("failed to compile recognizer pattern: " .. tostring(err))
+                log.error(
+                    "failed to compile recognizer pattern '"
+                    .. tostring(regex)
+                    .. "': "
+                    .. tostring(err)
+                )
             end
         end
     end
-    return patterns
+
+    return matchers
 end
 
 -- 检查数字后是否紧跟功能编码 (KpNumber 使用)
 local function is_function_code_after_digit(env, context, digit_char)
     if not context or not digit_char or digit_char == "" then return false end
+
+    -- digit_char 必为数字，因此这里传入 regex_matches() 的 input 保证非空。
     local input = (context.input or "") .. digit_char
-    local patterns = env.kp_func_patterns
-    if not patterns then return false end
-    for _, matcher in ipairs(patterns) do
-        if wanxiang.regex_matches(matcher, input) then return true end
+    local matchers = env.kp_func_matchers
+    if not matchers then return false end
+
+    for _, matcher in ipairs(matchers) do
+        if wanxiang.regex_matches(matcher, input) then
+            return true
+        end
     end
+
     return false
 end
 
@@ -309,7 +321,7 @@ function M.init(env)
     env.kp_page_size = config:get_int("menu/page_size") or 6
     local m = config:get_string("super_processor/kp_number_mode") or "select"
     env.kp_mode = (m == "auto" or m == "compose" or m == "select") and m or "select"
-    env.kp_func_patterns = load_rime_regex_patterns(config, "recognizer/patterns")
+    env.kp_func_matchers = load_rime_regex_matchers(config, "recognizer/patterns")
 
     -- [LetterSelector] 字母选词状态位
     env.ls_active = false 

--- a/lua/wanxiang/wanxiang.lua
+++ b/lua/wanxiang/wanxiang.lua
@@ -262,6 +262,72 @@ function wanxiang.get_user_id()
     installation_file:close()
     return user_id
 end
+---@class WanxiangRegexMatcher
+---@field projection Projection
+---@field pattern string
+
+-- Projection 没有直接暴露 bool match 接口；这里用单条 erase 规则把
+-- “完整匹配 / 不匹配”映射为“空字符串 / 原字符串”。
+-- matcher 在初始化时构建一次，热路径只执行已编译正则的匹配。
+-- 此做法缘起规避直接暴露的接口在一些Linux机型上导致fcitx5异常退出，但其缓存初始化的做法其实在性能上更优。
+local REGEX_DELIMITERS = { "#", "%", ";", "~", "|", "@", "/", "!", ",", "=", "_" }
+
+---@param pattern string
+---@return WanxiangRegexMatcher|nil matcher
+---@return string|nil error_message
+function wanxiang.compile_regex(pattern)
+    if type(pattern) ~= "string" or pattern == "" then
+        return nil, "pattern must be a non-empty string"
+    end
+
+    local delimiter = nil
+    for _, candidate in ipairs(REGEX_DELIMITERS) do
+        if not pattern:find(candidate, 1, true) then
+            delimiter = candidate
+            break
+        end
+    end
+
+    if not delimiter then
+        return nil, "pattern contains every supported projection delimiter"
+    end
+
+    local projection = Projection()
+    local rule = "erase" .. delimiter .. pattern .. delimiter
+    local ok, loaded = pcall(function()
+        return projection:load({ rule })
+    end)
+
+    if not ok then
+        return nil, tostring(loaded)
+    end
+    if not loaded then
+        return nil, "projection rejected pattern: " .. pattern
+    end
+
+    return {
+        projection = projection,
+        pattern = pattern,
+    }
+end
+
+---@param matcher WanxiangRegexMatcher|nil
+---@param input string
+---@return boolean
+function wanxiang.regex_matches(matcher, input)
+    if not matcher or not matcher.projection or type(input) ~= "string" then
+        return false
+    end
+
+    -- erase 匹配成功和“空输入未匹配”都会得到空字符串，因此该兼容层
+    -- 明确只用于当前两处非空编码匹配场景。
+    if input == "" then
+        return false
+    end
+
+    return matcher.projection:apply(input, true) == ""
+end
+
 wanxiang.INPUT_METHOD_MARKERS = {
     ["Ⅰ"] = "pinyin",   -- 全拼
     ["Ⅱ"] = "zrm",      -- 自然码双拼
@@ -294,104 +360,6 @@ local INPUT_METHOD_MARKER_ORDER = {
 }
 
 local INPUT_METHOD_MD_MARKER = "ⅲ"
-
----@class WanxiangRegexMatcher
----@field backend "native"|"projection"
----@field pattern string|nil
----@field projection Projection|nil
-
-local REGEX_DELIMITERS = { "#", "%", ";", "~", "|", "@", "/", "!", ",", "=", "_" }
-local regex_backend = nil
-
-local function is_opensuse()
-    local file = io.open("/etc/os-release", "r")
-    if not file then file = io.open("/usr/lib/os-release", "r") end
-    if not file then return false end
-
-    local matched = false
-    for line in file:lines() do
-        local key, value = line:match("^([A-Z_]+)=(.*)$")
-        if key == "ID" or key == "ID_LIKE" then
-            value = value:gsub("^['\"]", ""):gsub("['\"]$", ""):lower()
-            if value:find("opensuse", 1, true) or value:match("%f[%a]suse%f[%A]") then
-                matched = true
-                break
-            end
-        end
-    end
-    file:close()
-    return matched
-end
-
---- openSUSE's current librime-lua package crashes inside rime_api.regex_match.
---- Other platforms keep the native backend unless explicitly overridden.
----@return "native"|"projection"
-function wanxiang.get_regex_backend()
-    if regex_backend then return regex_backend end
-
-    local override = os.getenv("WANXIANG_REGEX_BACKEND")
-    if override == "native" or override == "projection" then
-        regex_backend = override
-    else
-        regex_backend = is_opensuse() and "projection" or "native"
-    end
-    return regex_backend
-end
-
----@param pattern string
----@return WanxiangRegexMatcher|nil matcher
----@return string|nil error_message
-function wanxiang.compile_regex(pattern)
-    if type(pattern) ~= "string" or pattern == "" then
-        return nil, "pattern must be a non-empty string"
-    end
-
-    if wanxiang.get_regex_backend() == "native" then
-        local ok, err = pcall(rime_api.regex_match, "", pattern)
-        if not ok then return nil, tostring(err) end
-        return { backend = "native", pattern = pattern }
-    end
-
-    local delimiter = nil
-    for _, candidate in ipairs(REGEX_DELIMITERS) do
-        if not pattern:find(candidate, 1, true) then
-            delimiter = candidate
-            break
-        end
-    end
-    if not delimiter then
-        return nil, "pattern contains every supported projection delimiter"
-    end
-
-    local projection = Projection()
-    local rule = "erase" .. delimiter .. pattern .. delimiter
-    local ok, loaded = pcall(function()
-        return projection:load({ rule })
-    end)
-    if not ok or not loaded then
-        return nil, ok and "projection rejected the pattern" or tostring(loaded)
-    end
-    return { backend = "projection", projection = projection }
-end
-
----@param matcher WanxiangRegexMatcher|nil
----@param input string
----@return boolean
-function wanxiang.regex_matches(matcher, input)
-    if not matcher or type(input) ~= "string" then return false end
-
-    if matcher.backend == "native" then
-        return matcher.pattern ~= nil and rime_api.regex_match(input, matcher.pattern)
-    end
-
-    -- Projection cannot distinguish an empty match from an unchanged empty input.
-    -- Current callers always match non-empty composing input.
-    if input == "" or not matcher.projection then return false end
-    local ok, result = pcall(function()
-        return matcher.projection:apply(input, true)
-    end)
-    return ok and result == ""
-end
 
 --- 返回形式：
 ---   id

--- a/lua/wanxiang/wanxiang.lua
+++ b/lua/wanxiang/wanxiang.lua
@@ -295,6 +295,104 @@ local INPUT_METHOD_MARKER_ORDER = {
 
 local INPUT_METHOD_MD_MARKER = "ⅲ"
 
+---@class WanxiangRegexMatcher
+---@field backend "native"|"projection"
+---@field pattern string|nil
+---@field projection Projection|nil
+
+local REGEX_DELIMITERS = { "#", "%", ";", "~", "|", "@", "/", "!", ",", "=", "_" }
+local regex_backend = nil
+
+local function is_opensuse()
+    local file = io.open("/etc/os-release", "r")
+    if not file then file = io.open("/usr/lib/os-release", "r") end
+    if not file then return false end
+
+    local matched = false
+    for line in file:lines() do
+        local key, value = line:match("^([A-Z_]+)=(.*)$")
+        if key == "ID" or key == "ID_LIKE" then
+            value = value:gsub("^['\"]", ""):gsub("['\"]$", ""):lower()
+            if value:find("opensuse", 1, true) or value:match("%f[%a]suse%f[%A]") then
+                matched = true
+                break
+            end
+        end
+    end
+    file:close()
+    return matched
+end
+
+--- openSUSE's current librime-lua package crashes inside rime_api.regex_match.
+--- Other platforms keep the native backend unless explicitly overridden.
+---@return "native"|"projection"
+function wanxiang.get_regex_backend()
+    if regex_backend then return regex_backend end
+
+    local override = os.getenv("WANXIANG_REGEX_BACKEND")
+    if override == "native" or override == "projection" then
+        regex_backend = override
+    else
+        regex_backend = is_opensuse() and "projection" or "native"
+    end
+    return regex_backend
+end
+
+---@param pattern string
+---@return WanxiangRegexMatcher|nil matcher
+---@return string|nil error_message
+function wanxiang.compile_regex(pattern)
+    if type(pattern) ~= "string" or pattern == "" then
+        return nil, "pattern must be a non-empty string"
+    end
+
+    if wanxiang.get_regex_backend() == "native" then
+        local ok, err = pcall(rime_api.regex_match, "", pattern)
+        if not ok then return nil, tostring(err) end
+        return { backend = "native", pattern = pattern }
+    end
+
+    local delimiter = nil
+    for _, candidate in ipairs(REGEX_DELIMITERS) do
+        if not pattern:find(candidate, 1, true) then
+            delimiter = candidate
+            break
+        end
+    end
+    if not delimiter then
+        return nil, "pattern contains every supported projection delimiter"
+    end
+
+    local projection = Projection()
+    local rule = "erase" .. delimiter .. pattern .. delimiter
+    local ok, loaded = pcall(function()
+        return projection:load({ rule })
+    end)
+    if not ok or not loaded then
+        return nil, ok and "projection rejected the pattern" or tostring(loaded)
+    end
+    return { backend = "projection", projection = projection }
+end
+
+---@param matcher WanxiangRegexMatcher|nil
+---@param input string
+---@return boolean
+function wanxiang.regex_matches(matcher, input)
+    if not matcher or type(input) ~= "string" then return false end
+
+    if matcher.backend == "native" then
+        return matcher.pattern ~= nil and rime_api.regex_match(input, matcher.pattern)
+    end
+
+    -- Projection cannot distinguish an empty match from an unchanged empty input.
+    -- Current callers always match non-empty composing input.
+    if input == "" or not matcher.projection then return false end
+    local ok, result = pcall(function()
+        return matcher.projection:apply(input, true)
+    end)
+    return ok and result == ""
+end
+
 --- 返回形式：
 ---   id
 ---   id, "ⅲ"  -- 命中辅助标记时


### PR DESCRIPTION
## 问题描述

在 openSUSE 上安装 `librime-lua` 后，启用万象拼音时 Fcitx5 会收到 `SIGSEGV` 并退出。经过逐步隔离，问题发生在万象 Lua 初始化期间调用：

```lua
rime_api.regex_match(input, pattern)
```

即使使用最简单的固定表达式也能稳定复现：

```lua
pcall(rime_api.regex_match, "", "^$")
```

该调用不会返回 Lua 错误，而是直接在 `librime-lua.so` 的原生代码中触发段错误，因此无法通过 Lua `pcall` 捕获。

## 运行环境

```text
系统：openSUSE Tumbleweed 20260901
内核：Linux 7.2.2-1-default
架构：x86_64

Fcitx5：5.1.17
fcitx5-rime：5.1.12-1.5
librime1：1.17.0-1.1
librime-lua：0.0.0+git20250809.68f9c36-3.1
liblua5_4-5：5.4.8-4.6
Boost：1.91
```

相关 RPM 均来自 openSUSE 官方仓库，`rpm -V` 校验正常，动态链接也确认使用系统的：

```text
/lib64/librime.so.1
/lib64/rime-plugins/librime-lua.so
/lib64/liblua5.4.so.5
```

## 崩溃堆栈

关键堆栈如下：

```text
Fcitx 5.1.17 -- Get Signal No.: 11

/lib64/rime-plugins/librime-lua.so(+0x61940)
/lib64/rime-plugins/librime-lua.so(+0xa7d90)
/lib64/rime-plugins/librime-lua.so(+0x9e8ad)
/lib64/rime-plugins/librime-lua.so(+0x61e1e)
/lib64/rime-plugins/librime-lua.so(+0x8878a)
/lib64/liblua5.4.so.5(lua_pcallk+0x94)
/lib64/rime-plugins/librime-lua.so(
  _ZN7LuaImpl11wrap_commonEP9lua_StatePFiS1_E+0x84
)
/lib64/rime-plugins/librime-lua.so(
  _ZN4rime12LuaProcessorC1ERKNS_6TicketEP3Lua+0xd0
)
/lib64/librime.so.1(
  _ZN4rime14ConcreteEngine20InitializeComponentsEv+0x455
)
/lib64/librime.so.1(
  _ZN4rime6Engine6CreateEv+0x22
)
```

## 定位过程

对 `wanxiang.super_processor` 的初始化过程进行逐段隔离后，确认：

- Lua 模块加载正常；
- `ConfigList` 和 `ConfigValue` 读取正常；
- `config:get_map()` 正常；
- `ConfigMap:keys()` 正常；
- `ConfigMap:get_value()` 正常；
- notifier 尚未连接时即可复现；
- 移除 `rime_api.regex_match()` 后 Fcitx5 可以正常启动；
- 单独恢复任意一次 `rime_api.regex_match()` 调用后立即崩溃。

因此，本问题不是由某条具体的 `recognizer/patterns` 正则导致，而是该环境中的 `rime_api.regex_match()` 包装本身存在兼容问题。

万象中受到影响的调用点主要包括：

```text
lua/wanxiang/super_processor.lua
lua/wanxiang/key_binder.lua
```

直接禁用这些匹配会损失以下功能：

- 小键盘及主键盘数字的功能指令识别；
- `key_binder/bindings` 中的 `match:` 条件；
- 用户自定义的正则按键绑定。

因此不宜简单删除相关逻辑。

## 修复方案

增加统一的正则编译和匹配兼容层：

```lua
wanxiang.compile_regex(pattern)
wanxiang.regex_matches(matcher, input)
wanxiang.get_regex_backend()
```

### 默认后端选择

- openSUSE 系统使用 `Projection` 后端；
- Windows、macOS、Android 和其他 Linux 默认继续使用原生 `rime_api.regex_match`；
- 允许通过环境变量显式覆盖：

```bash
WANXIANG_REGEX_BACKEND=native
WANXIANG_REGEX_BACKEND=projection
```

openSUSE 的识别依据为：

```text
/etc/os-release
/usr/lib/os-release
```

检查其中的 `ID` 和 `ID_LIKE` 是否包含 `opensuse` 或独立的 `suse` 标识。

### Projection 后端

通过 librime 核心的 `Projection` 加载：

```text
erase<delimiter><pattern><delimiter>
```

`erase` 的底层实现同样使用 `boost::regex_match`，匹配成功时会清空输入，未匹配时保持原输入。

对于万象当前两个调用点，待匹配输入均保证非空，因此：

```lua
projection:apply(input, true) == ""
```

可保持原有的完整字符串匹配语义。

分隔符从一组候选字符中自动选择，确保不会与正则内容冲突。

### 初始化与缓存

`recognizer/patterns` 和 `key_binder/bindings` 中的正则应在组件初始化时编译一次并缓存，避免在每次按键时重复创建 `Projection`。

编译失败时记录明确日志，不静默忽略，也不把无效 matcher 放入运行时列表。

## 预期行为

1. openSUSE Kalpa 安装 `librime-lua` 后可以正常启动 Fcitx5；
2. 万象拼音可以正常激活；
3. `/flypy` 等方案切换指令正常工作；
4. 数字功能指令判断保持原有行为；
5. `key_binder` 的 `match:` 正则条件保持原有行为；
6. 非 openSUSE 平台继续使用原生 `rime_api.regex_match`，不改变既有路径；
7. openSUSE 修复软件包后，可通过环境变量立即切回原生后端。

## 验证结果

已在上述 openSUSE 环境中验证：

- Fcitx5 可以正常启动；
- 可以正常切换到 Rime；
- `/flypy` 可以正常切换到小鹤双拼；
- 未产生新的 core dump；
- Lua 初始化日志无错误；
- 当前所有 `recognizer` 正则均能成功编译；
- 运行路径中不再调用有问题的 `rime_api.regex_match()`。